### PR TITLE
Remove retrying to load ipmb_host driver

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -86,18 +86,9 @@ if [ "$is_bluewhale" = "Bluewhale" ] || [ "$support_ipmb" = "1" ]; then
 	if [ ! "$(lsmod | grep ipmi_devintf)" ]; then
 		modprobe ipmi_devintf
 	fi
-	# poll every 18 seconds if the driver fails to load.
-	if [ $(( $t % 6 )) -eq 0 ] || [ "$t" = "$fru_timer" ]; then
-		if [ ! "$(lsmod | grep ipmb_host)" ]; then
-			modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
-			echo ipmb-host $IPMB_HOST_ADD > $I2C2_NEW_DEV
-
-			ipmitool mc info > /dev/null 2>&1
-			if [ ! $? -eq 0 ]; then
-				rmmod ipmb_host
-				echo $IPMB_HOST_ADD > $I2C2_DEL_DEV
-			fi
-		fi
+	if [ ! "$(lsmod | grep ipmb_host)" ]; then
+		modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
+		echo ipmb-host $IPMB_HOST_ADD > $I2C2_NEW_DEV
 	fi
 fi #support_ipmb
 


### PR DESCRIPTION
The ipmb_host driver is responsible for initiating IPMB requests
from the BF to the BMC. At boot time, this driver works on top
of ipmi_devintf and ipmi_msghandler to execute a handshake with
the BMC over IPMB. If the handshake succeeds, IPMB was setup
properly.

A while back, the customer who asked for the feature of supporting
IPMB requests from the BF to BMC, asked for a mechanism to keep
trying to load the ipmb_host driver if the handshake fails the
first time. The handshake can fail either due to the BMC being down,
or the BMC having some sort of panic or being busy.

Now, that same customer wants this behavior changed. They only want
to try loading the ipmb_host driver once at boot time. If it fails,
they will have to restart the set_emu_param.service or reboot the
BlueField to support BF->BMC transactions.

The motivation behind that is that they are overusing the I2C bus
in both directions. Their BMC is constantly trying to send IPMB
requests even when the BF is down. And they added on top of that
a script on the BF, which tries to send an IPMB command to the
BMC even if the ipmb_host driver hasn't been loaded yet.
Simultaneously, the set_emu_param.service is also trying to
periodically use the I2C bus to execute the ipmb_host handshake.
The handshake is slowed down because the I2C bus is busy and the
response time is delayed by a magnitude of seconds.
So the script thinks the handshake failed and tries it again some
time later.
By overusing the I2C bus in this manner, this creates a lot of
complications, delay and sometimes unexpected behavior.

So the best thing to do is free the I2C bus a bit by removing
the handshake retry logic.