### PR TITLE
support IPMI via OOB

### DIFF
--- a/lanserv/mellanox-bf/oneshot_emu_param.service
+++ b/lanserv/mellanox-bf/oneshot_emu_param.service
@@ -4,7 +4,7 @@ Description=Collect about BlueField's sensors and FRUs once
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/ipmi/progconf
-ExecStart=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} $SUPPORT_IPMB'
+ExecStart=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP}'
 
 [Install]
 WantedBy=multi-user.target

--- a/lanserv/mellanox-bf/poll_set_emu_param.sh
+++ b/lanserv/mellanox-bf/poll_set_emu_param.sh
@@ -4,8 +4,11 @@
 # $1 time interval for executing set_emu_param.sh in seconds.
 # $2 is set to "Bluewhale" if it is a BlueWhale board.
 # $3 should be set to 1 if IPMB is supported.
+# $4 should be set to the OOB ip address if supported.
+# example: "192.168.101.2". If OOB is not supported, $4
+# should be set to "0".
 
 while /bin/true; do
-	/usr/bin/set_emu_param.sh $2 $3
+	/usr/bin/set_emu_param.sh $2 $3 $4
 	sleep $1
 done

--- a/lanserv/mellanox-bf/progconf
+++ b/lanserv/mellanox-bf/progconf
@@ -1,3 +1,4 @@
 SUPPORT_IPMB=0
 LOOP_PERIOD=3
 BF_FAMILY=$(/opt/mlnx/scripts/bffamily | tr -d '[:space:]')
+OOB_IP="0"

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -4,7 +4,7 @@ After=oneshot_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB}'
+ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP}'
 StandardOutput=append:/var/log/set_emu_param.log
 StandardError=append:/var/log/set_emu_param.log
 

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -68,6 +68,7 @@ I2C2_DEL_DEV=/sys/bus/i2c/devices/i2c-2/delete_device
 
 is_bluewhale=$1
 support_ipmb=$2
+oob_ip=$3
 
 if [ "$is_bluewhale" = "Bluewhale" ] || [ "$support_ipmb" = "1" ]; then
 	# Instantiate the ipmb-dev device
@@ -91,6 +92,18 @@ if [ "$is_bluewhale" = "Bluewhale" ] || [ "$support_ipmb" = "1" ]; then
 		echo ipmb-host $IPMB_HOST_ADD > $I2C2_NEW_DEV
 	fi
 fi #support_ipmb
+
+if [ ! "$oob_ip" = "0" ]; then
+	if ! grep -q "startlan 2" /etc/ipmi/mlx-bf.lan.conf; then
+		cat <<- EOF >> /etc/ipmi/mlx-bf.lan.conf
+		  startlan 2
+		    addr $oob_ip 623
+		    priv_limit admin
+		    guid a123456789abcdefa123456789abcdef
+		  endlan
+		EOF
+	fi
+fi #oob_ip
 
 ###############################
 # Collect sensor and fru data #


### PR DESCRIPTION
https://redmine.mellanox.com/issues/2330349

The above is a request to add support for IPMI
via OOB. Now, the user can issue a command from
the external host to the BF via lanplus and get
a response back:
ipmitool -I lanplus -H 192.168.101.2 -U ADMIN -P ADMIN sensor list

Since this is only supported on certain BF-2 systems,
the user can enable this feature by simply setting
SUPPORT_OOB variable to 1 in progconf.
By default, SUPPORT_OOB=0.