### PR TITLE
Fix IPMI on BlueField-2

### DIFF
--- a/lanserv/mellanox-bf/oneshot_emu_param.service
+++ b/lanserv/mellanox-bf/oneshot_emu_param.service
@@ -4,7 +4,7 @@ Description=Collect about BlueField's sensors and FRUs once
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/ipmi/progconf
-ExecStart=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP}'
+ExecStart=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
 
 [Install]
 WantedBy=multi-user.target

--- a/lanserv/mellanox-bf/poll_set_emu_param.sh
+++ b/lanserv/mellanox-bf/poll_set_emu_param.sh
@@ -9,6 +9,6 @@
 # should be set to "0".
 
 while /bin/true; do
-	/usr/bin/set_emu_param.sh $2 $3 $4
+	/usr/bin/set_emu_param.sh $2 $3 $4 $5
 	sleep $1
 done

--- a/lanserv/mellanox-bf/progconf
+++ b/lanserv/mellanox-bf/progconf
@@ -1,4 +1,5 @@
 SUPPORT_IPMB="NONE"
+EXTERNAL_DDR="NO"
 LOOP_PERIOD=3
 BF_FAMILY=$(/usr/bin/bffamily | tr -d '[:space:]')
 OOB_IP="0"

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -4,7 +4,7 @@ After=oneshot_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP}'
+ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
 StandardOutput=append:/var/log/set_emu_param.log
 StandardError=append:/var/log/set_emu_param.log
 

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -62,6 +62,7 @@ IPMB_HOST_CLIENTADDR=0x10
 bffamily=$1
 support_ipmb=$2
 oob_ip=$3
+external_ddr=$4
 
 if [ "$bffamily" = "Bluewhale" ]; then
 	i2cbus=2
@@ -279,10 +280,11 @@ SPDS_ADDR="$SPD0_I2C_ADDR $SPD1_I2C_ADDR $SPD2_I2C_ADDR $SPD3_I2C_ADDR"
 
 I2C1_DEVPATH=/sys/bus/i2c/devices/i2c-1/new_device
 
-if [ ! "$(lsmod | grep ee1004)" ]; then
-	modprobe ee1004
+if [ "$bffamily" = "Bluewhale" ] || [ "$external_ddr" = "YES" ]; then
+	if [ ! "$(lsmod | grep ee1004)" ]; then
+		modprobe ee1004
+	fi
 fi
-
 if [ "$(lsmod | grep ee1004)" ]; then
 	# Up to 4 SPDs can be connected to I2C bus 1. To
 	# read information contained in those SPDs, the ee1004
@@ -304,11 +306,13 @@ fi
 ###############################################
 #           Get DIMMs' temperature            #
 ###############################################
-if [ ! "$(lsmod | grep jc42)" ]; then
-	modprobe jc42
+if [ "$bffamily" = "Bluewhale" ] || [ "$external_ddr" = "YES" ]; then
+	if [ ! "$(lsmod | grep jc42)" ]; then
+		modprobe jc42
 
-	if [ "$(lsmod | grep jc42)" ]; then
-		sensors -s
+		if [ "$(lsmod | grep jc42)" ]; then
+			sensors -s
+		fi
 	fi
 fi
 
@@ -425,8 +429,8 @@ fi
 
 wc -c $EMU_PARAM_DIR/nic_pci_dev_info | cut -f 1 -d " " > $EMU_PARAM_DIR/nic_pci_dev_info_filelen
 
-rm $EMU_PARAM_DIR/eth_bdfs.txt
-rm $EMU_PARAM_DIR/ib_bdfs.txt
+rm -f $EMU_PARAM_DIR/eth_bdfs.txt
+rm -f $EMU_PARAM_DIR/ib_bdfs.txt
 
 
 ###################################


### PR DESCRIPTION
On some BlueField-2 systems, after powercycling,
the set_emu_param.sh script causes a kernel panic.
This is due to trying to detect/instantiate i2c
devices (ee1004 and jc42) which are only needed
on systems that support external DDRs.
None of the BlueField-2 systems support external
DDRs.
This does not happen after software reset.

Although this is not the source of the
problem, it is important to handle this case.
The source of the issue is the i2c interface
causing a panic. But it will not be handled in
this patch.