### PR TITLE
Typo in IPMB channel

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -81,7 +81,7 @@ if [ "$i2cbus" != "NONE" ]; then
 	fi
 
 	if ! grep -q "ipmb-$i2cbus" /etc/ipmi/mlx-bf.lan.conf; then
-		echo "  ipmb $i2cbus ipmb_dev_int /dev/ipmb-$i2cbus" >> /etc/ipmi/mlx-bf.lan.conf
+		echo "  ipmb 2 ipmb_dev_int /dev/ipmb-$i2cbus" >> /etc/ipmi/mlx-bf.lan.conf
 	fi
 
 	# load the ipmb_host driver


### PR DESCRIPTION
We should always be using the IPMI channel 2 corresponding
to IPMB. There is a typo that was setting it to 1 (LAN)
on the bluesphere.