### PR TITLE
ipmi_sim crashed after powercycling the BF

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -118,8 +118,9 @@ remove_sensor() {
 }
 
 add_fru() {
-	if [ $(cat $EMU_PARAM_DIR/$1"_filelen") -gt 0 ]; then
-		echo "mc_add_fru_data 0x30 $2 $(cat $EMU_PARAM_DIR/$1"_filelen") file 0 \"$EMU_PARAM_DIR/$1\"" >> $EMU_FILE_PATH
+	filelen=$(cat $EMU_PARAM_DIR/$1"_filelen")
+	if [ $filelen -gt 0 ]; then
+		echo "mc_add_fru_data 0x30 $2 $filelen file 0 \"$EMU_PARAM_DIR/$1\"" >> $EMU_FILE_PATH
 	fi
 }
 
@@ -701,8 +702,4 @@ if [ "$t" = "$fru_timer" ]; then
 	add_fru "bf_uid" 15
 
 	echo "mc_enable 0x30" >> $EMU_FILE_PATH
-else
-	#update the fru timer
-	ipmb_update_timer_fru=$(echo "mc_add_fru_data 0x30 0 6 file 0 \"$EMU_PARAM_DIR/ipmb_update_timer\"")
-	sed -i "s~.*ipmb_update_timer.*~$ipmb_update_timer_fru~" $EMU_FILE_PATH
 fi


### PR DESCRIPTION
Our customer reported a bug that we only
are able to reproduce using an opensource
centos image (as opposed to our CentOS.bfb)

Steps to reproduce:

On bluewhale, install CentOS image from
opensource. Install the IPMB drivers and
OpenIPMI packages. Then powercycle the
BF. After the BF has rebooted, the mlx_ipmid
service fails to come up.

Source of the problem:

This is due to the mlx-bf.emu file being
wiped out after powercycling. ipmi_sim program
depends on mlx-bf.emu to start executing.
It gets wiped out due to (an unnecessary) sed
command meant to update a line in mlx-bf.emu.
It is unnessary to update that line because
once the ipmb_update_timer fru has been added
at time t=0x4b0, there is no need to change it
again.

RM #2396784