### PR TITLE
Temporary workaround for BlueSphere crash due to ipmb-host

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -92,8 +92,15 @@ if [ "$i2cbus" != "NONE" ]; then
 		modprobe ipmi_devintf
 	fi
 	if [ ! "$(lsmod | grep ipmb_host)" ]; then
-		modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
-		echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+		if [ "$bffamily" = "BlueSphere" ]; then
+			if [ ! "$t" = "$fru_timer" ] && [ $(( $t % 60 )) -eq 0 ]; then
+				modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
+				echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+			fi
+		else
+			modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
+			echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+		fi
 	fi
 fi #support_ipmb
 


### PR DESCRIPTION
After powercycling, the ipmb-host driver tries to
execute a handshake with the BMC and fails because the
BMC is not up yet. This causes a kernel calltrace and
eventually stops responding because there is and ipmi_msghandler
event thats holding a task for too long (forever).

Just to unblock other teams progress, the workaround for now,
is to delay the loading of the ipmb_host driver by 3mn.

I will get back to this and solve it properly from the drivers.