### PR TITLE
Fix connectX FRUs in CentOS

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -218,7 +218,7 @@ get_connectx_net_info() {
 	isdhcp=false
 
 	# Check if IPv4 address is assigned
-	ifconfig $eth | grep "inet addr:"
+	ifconfig $eth | grep "inet "
 	if [ $? -eq 0 ]; then
 
 		# On Yocto and Ubuntu
@@ -244,7 +244,7 @@ get_connectx_net_info() {
 	isdhcp=false
 
 	# Check if IPv6 address is assigned and is not a link local address
-	ifconfig $eth | grep "inet6 addr:" | grep -v "fe80"
+	ifconfig $eth | grep "inet6 " | grep -v "fe80"
 	if [ $? -eq 0 ]; then
 
 		# On Yocto and Ubuntu


### PR DESCRIPTION
On CentOS, the connectX FRU fails to report the ip address
origin. This is because we grep for "inet addr:" which is
valid for Yocto but not on CentOS where we should be grepping
for "inet ".

RM #2421292