### PR TITLE
Fix comparison operators

### DIFF
--- a/debian/mlx-openipmi.init
+++ b/debian/mlx-openipmi.init
@@ -52,7 +52,7 @@ case $(uname -m) in
         IPMI_SI_MODULE_NAME="ipmi_si" ;;
 esac
 kernel=`uname -r | cut -d. -f1-2`
-if [ "${kernel}" == "2.4" ]; then
+if [ "${kernel}" = "2.4" ]; then
     IPMI_SMB_MODULE_NAME="ipmi_smb_intf"
     IPMI_SI_MODULE_NAME="ipmi_si_drv"
 fi
@@ -242,7 +242,7 @@ start_powercontrol_common()
 {
 	local poweroff_opts=""
 	load_hw_modules
-	if [ "${IPMI_POWERCYCLE}" == "yes" ]; then
+	if [ "${IPMI_POWERCYCLE}" = "yes" ]; then
 	    modinfo ipmi_poweroff 2>/dev/null | grep poweroff_control > /dev/null 2>&1 && \
 		poweroff_opts="poweroff_control=2"
 	    modinfo ipmi_poweroff 2>/dev/null | grep poweroff_powercycle > /dev/null 2>&1 && \


### PR DESCRIPTION
Change comparison operator from "==" to "=" for POSIX shell compliance. Otherwise sh fails.