### PR TITLE
Fix CentOS and Ubuntu build

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -3,3 +3,5 @@ lib/systemd/system
 etc/ipmi
 var/ipmi_sim/mellanox
 etc/default
+var/log/set_emu_param
+var/log/mlx_ipmid

--- a/debian/mlx-openipmi.files
+++ b/debian/mlx-openipmi.files
@@ -8,3 +8,5 @@ usr/share/man/man5/*.5
 usr/share/man/man7/ipmi_cmdlang.7
 usr/share/man/man7/openipmi_conparms.7
 usr/share/man/man8/ipmilan.8
+/etc/logrotate.d/mlx_ipmid
+/etc/logrotate.d/set_emu_param

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -96,6 +96,10 @@ make %{?_smp_mflags}
 /lib/systemd/system/oneshot_emu_param.service
 /lib/systemd/system/set_emu_param.service
 /lib/systemd/system/mlx_ipmid.service
+/var/log/mlx_ipmid
+/var/log/set_emu_param
+/etc/logrotate.d/mlx_ipmid
+/etc/logrotate.d/set_emu_param
 
 %changelog
 * Wed Jan 23 2019 Asmaa Mnebhi <asmaa@mellanox.com> - 0.1-1


### PR DESCRIPTION
Changes made in the logrotate were not ported
to the RPM/DEB packages. As a result IPMI services
fail to start on CentOS and Ubuntu.