### PR TITLE
Support IPMB on Camelantis and Aztlan

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -66,7 +66,8 @@ external_ddr=$4
 
 if [ "$bffamily" = "Bluewhale" ]; then
 	i2cbus=2
-elif [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ]; then
+elif [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ] ||
+     [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ]; then
 	i2cbus=1
 else
 	i2cbus=$support_ipmb
@@ -92,7 +93,8 @@ if [ "$i2cbus" != "NONE" ]; then
 		modprobe ipmi_devintf
 	fi
 	if [ ! "$(lsmod | grep ipmb_host)" ]; then
-		if [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ]; then
+		if [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ] ||
+		   [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ]; then
 			if [ ! "$t" = "$fru_timer" ] && [ $(( $t % 60 )) -eq 0 ]; then
 				modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
 				echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV


### PR DESCRIPTION
Both Camelantis and Aztlan are connected to the BMC
via I2C1. So IPMB should be supported on that bus.