### PR TITLE
Fix link status for ib

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -438,7 +438,7 @@ else
 	if [ -s $EMU_PARAM_DIR/ib_bdfs.txt ]; then
 		while read bdf; do
 			func=$(echo $bdf | cut -f 1 -d " " | cut -f 2 -d ".")
-			link_status=$(cat /sys/class/net/ib*/operstate)
+			link_status=$(cat /sys/class/net/ib*$func/operstate)
 
 			if [ "$link_status" = "up" ]; then
 				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 2 $EMU_PARAM_DIR/p$func"_link") ]; then


### PR DESCRIPTION
This line link_status=$(cat /sys/class/net/ib*/operstate),
end ups with this if both links are up:
root@localhost:/usr/bin# cat /sys/class/net/ib*/operstate
up
up