### PR TITLE
Support log forwarding on CentOS

### DIFF
--- a/debian/mlx-openipmi.files
+++ b/debian/mlx-openipmi.files
@@ -10,3 +10,5 @@ usr/share/man/man7/openipmi_conparms.7
 usr/share/man/man8/ipmilan.8
 /etc/logrotate.d/mlx_ipmid
 /etc/logrotate.d/set_emu_param
+/etc/rsyslog.d/mlx_ipmid.conf
+/etc/rsyslog.d/set_emu_param.conf

--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -15,8 +15,11 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/set_emu_param/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
+	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param";
+	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"; \
+	$(INSTALL) -m 644 $(srcdir)/set_emu_param.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf";
 
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/oneshot_emu_param.service"
@@ -30,6 +33,8 @@ uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
+	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
+	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
 	-rmdir "$(DESTDIR)$(localstatedir)/log/mlx_ipmid" 2>/dev/null
 	-rmdir "$(DESTDIR)$(localstatedir)/log/set_emu_param" 2>/dev/null
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -512,8 +512,11 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/set_emu_param/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
+	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param";
+	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"; \
+	$(INSTALL) -m 644 $(srcdir)/set_emu_param.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf";
 
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/oneshot_emu_param.service"
@@ -527,6 +530,8 @@ uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
+	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
+	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
 	-rmdir "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"
 	-rmdir "$(DESTDIR)$(localstatedir)/log/set_emu_param/"
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null

--- a/lanserv/mellanox-bf/mlx_ipmid.conf
+++ b/lanserv/mellanox-bf/mlx_ipmid.conf
@@ -1,0 +1,2 @@
+if $programname == 'ipmi_sim' then /var/log/mlx_ipmid/mlx_ipmid.log
+&stop

--- a/lanserv/mellanox-bf/set_emu_param.conf
+++ b/lanserv/mellanox-bf/set_emu_param.conf
@@ -1,0 +1,2 @@
+if $programname == 'setipmi' then /var/log/set_emu_param/set_emu_param.log
+& stop

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -7,6 +7,7 @@ EnvironmentFile=/etc/ipmi/progconf
 ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
 StandardOutput=append:/var/log/set_emu_param/set_emu_param.log
 StandardError=append:/var/log/set_emu_param/set_emu_param.log
+SyslogIdentifier=setipmi
 
 [Install]
 WantedBy=multi-user.target

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -100,6 +100,8 @@ make %{?_smp_mflags}
 /var/log/set_emu_param
 /etc/logrotate.d/mlx_ipmid
 /etc/logrotate.d/set_emu_param
+/etc/rsyslog.d/mlx_ipmid.conf
+/etc/rsyslog.d/set_emu_param.conf
 
 %changelog
 * Wed Jan 23 2019 Asmaa Mnebhi <asmaa@mellanox.com> - 0.1-1


### PR DESCRIPTION
On Ubuntu and Yocto, set_emu_param.service and mlx_ipmid.service
logs are forwarded to /var/log/set_emu_param/set_emu_param.log
and /var/log/mlx_ipmid/mlx_ipmid.log instead of spamming the
/var/log/messages file.

CentOS is missing a change made in the rsyslog.d directory to
enforce the above change.

RM #2596726