### PR TITLE
Add dependencies on rasdaemon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: mlx-openipmi
 Section: admin
 Priority: optional
 Maintainer: Noël Köthe <noel@debian.org>
+Depends: rasdaemon
 Build-Depends: debhelper (>> 11.0.0), libsnmp-dev, libpopt-dev, libncurses5-dev, chrpath, libssl-dev, dh-systemd
 Standards-Version: 4.1.4
 Homepage: http://openipmi.sourceforge.net/

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -40,6 +40,7 @@ Group: System Environment/Base
 Source: %{_name}-%{_version}.tar.gz
 BuildRoot: %{?build_root:%{build_root}}%{!?build_root:/var/tmp/OFED}
 Vendor: Mellanox Technologies
+Requires: rasdaemon
 
 
 %description


### PR DESCRIPTION
Add dependency of the OpenIPMI package on rasdaemon in
both the spec file and the deb package.