### PR TITLE
Support eth0/eth1 fru for infiniband

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -193,7 +193,10 @@ get_connectx_net_info() {
 	# the SNIC, the connectX interfaces are renamed p0 and p1
 	eth=$(ifconfig -a | grep "enp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":")
 	if [ -z $eth ]; then
-		eth="p$1"
+		eth=$(ifconfig -a | grep "ibp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":")
+		if [ -z $eth ]; then
+			eth="p$1"
+		fi
 	fi
 
 	if [ "$1" = "0" ]; then


### PR DESCRIPTION
In switchdev mode, ConnectX interfaces are always named p0/p1.
BlueField in Smart NIC configuration always uses switchdev mode.
The enp*0/1 and ibp*0/1 naming scheme is the default naming
convention of the OS and is used on the BlueWhale.

Verification has been testing FRU 13 and 14 on the BlueWhale
with ib enabled instead of ethernet. So we need to support
parsing ifconfig for "ib*" as well.

RM #2627070