### PR TITLE
Fix logic for collecting QSFP EEPROM data

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf.emu
+++ b/lanserv/mellanox-bf/mlx-bf.emu
@@ -63,12 +63,12 @@ sensor_add 0x30 0 6 0x01 0x01	\
 # QSFP port 0 link status
 sensor_add 0x30 0 7 0x1b 0x6f	\
 	poll 5000		\
-	file "/var/emu_param/p0_link"
+	file "/tmp/p0_link"
 
 # QSFP port 1 link status
 sensor_add 0x30 0 8 0x1b 0x6f	\
 	poll 5000		\
-	file "/var/emu_param/p1_link"
+	file "/tmp/p1_link"
 
 ########## FRUs ##########
 

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -410,8 +410,8 @@ if [ ! -s $EMU_PARAM_DIR/eth_bdfs.txt ] && [ ! -s $EMU_PARAM_DIR/ib_bdfs.txt ]; 
 	Unable to get NIC PCI device info since the network ports are not configured.
 	EOF
 
-	echo 2 > $EMU_PARAM_DIR/p0_link
-	echo 2 > $EMU_PARAM_DIR/p1_link
+	echo 2 > /tmp/p0_link
+	echo 2 > /tmp/p1_link
 else
 	bdf_eth=$(head -n 1 $EMU_PARAM_DIR/eth_bdfs.txt)
 	bdf_ib=$(head -n 1 $EMU_PARAM_DIR/ib_bdfs.txt)
@@ -427,14 +427,14 @@ else
 			func=$(echo $bdf | cut -f 1 -d " " | cut -f 2 -d ".")
 
 			if [ "$link_status" = "up" ]; then
-				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 2 $EMU_PARAM_DIR/p$func"_link") ]; then
+				if [ ! -f /tmp/p$func"_link" ] || [ $(grep 2 /tmp/p$func"_link") ]; then
 					eval "p${func}_changed=1"
-					echo 1 > $EMU_PARAM_DIR/p$func"_link"
+					echo 1 > /tmp/p$func"_link"
 				fi
 			else
-				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 1 $EMU_PARAM_DIR/p$func"_link") ]; then
+				if [ ! -f /tmp/p$func"_link" ] || [ $(grep 1 /tmp/p$func"_link") ]; then
 					eval "p${func}_changed=1"
-					echo 2 > $EMU_PARAM_DIR/p$func"_link"
+					echo 2 > /tmp/p$func"_link"
 				fi
 			fi
 		done <$EMU_PARAM_DIR/eth_bdfs.txt
@@ -446,14 +446,14 @@ else
 			link_status=$(cat /sys/class/net/ib*$func/operstate)
 
 			if [ "$link_status" = "up" ]; then
-				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 2 $EMU_PARAM_DIR/p$func"_link") ]; then
+				if [ ! -f /tmp/p$func"_link" ] || [ $(grep 2 /tmp/p$func"_link") ]; then
 					eval "p${func}_changed=1"
-					echo 1 > $EMU_PARAM_DIR/p$func"_link"
+					echo 1 > /tmp/p$func"_link"
 				fi
 			else
-				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 1 $EMU_PARAM_DIR/p$func"_link") ]; then
+				if [ ! -f /tmp/p$func"_link" ] || [ $(grep 1 /tmp/p$func"_link") ]; then
 					eval "p${func}_changed=1"
-					echo 2 > $EMU_PARAM_DIR/p$func"_link"
+					echo 2 > /tmp/p$func"_link"
 				fi
 			fi
 		done <$EMU_PARAM_DIR/ib_bdfs.txt


### PR DESCRIPTION
The QSFP eeprom data is only updated if the link status has changed.
After reboot, the QSFP eeprom data is not collected because of the
logic below:
if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 2 $EMU_PARAM_DIR/p$func"_link") ]; then

the p0_link and p1_link files are persistent accross reboots so they
hold the same value. So the above if statement is never true after
reboot.

This issue is fixed by making the p0_link and p1_link non
persistent accross reboots.

RM #2659049