### PR TITLE
Add support for multiple LOOP_PERIOD values

### DIFF
--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -5,7 +5,7 @@ Before=set_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStartPre=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
+ExecStartPre=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD}'
 ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always
 RestartSec=10

--- a/lanserv/mellanox-bf/poll_set_emu_param.sh
+++ b/lanserv/mellanox-bf/poll_set_emu_param.sh
@@ -9,6 +9,6 @@
 # should be set to "0".
 
 while /bin/true; do
-	/usr/bin/set_emu_param.sh $2 $3 $4 $5
+	/usr/bin/set_emu_param.sh $2 $3 $4 $5 $1
 	sleep $1
 done


### PR DESCRIPTION
The set_emu_param.sh script runs periodically every 3s.
So, it runs several MFT commands every 3s to collect temp
values amongst other things.
The MFT tools take a lot of CPU cycle and impact the overall
performance of SNAP: #2677674.
SNAP itself consumes a lot of CPU cycles and is disabled by default.
Instead of disabling set_emu_param.service by default, we
decided to change the LOOP_PERIOD default in Ubuntu and CentOS
from 3s to 60s.

The change above results in ipmb_host driver being loaded
20mn after boot instead of 2mn. This is because all timing
parameters in the set_emu_param.sh script are hardcoded
based on LOOP_PERIOD=3s. So we will make the code more generic
to adjust to any LOOP_PERIOD value passed by the user.