### PR TITLE
Fix eth0/eth1 FRUs when VLAN is supported

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -201,9 +201,10 @@ get_connectx_net_info() {
 	# In the BlueWhale and other similar designs,
 	# udev renames the interfaces to enp*f* while on
 	# the SNIC, the connectX interfaces are renamed p0 and p1
-	eth=$(ifconfig -a | grep "enp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":")
+	# Make sure to parse out the VLAN interfaces as well. For ex: enp3s0f0np0.100
+	eth=$(ifconfig -a | grep "enp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":" | head -1 | cut -f 1 -d ".")
 	if [ -z $eth ]; then
-		eth=$(ifconfig -a | grep "ibp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":")
+		eth=$(ifconfig -a | grep "ibp.*f$1" | cut -f 1 -d " " | cut -f 1 -d ":" | head -1 | cut -f 1 -d ".")
 		if [ -z $eth ]; then
 			eth="p$1"
 		fi


### PR DESCRIPTION
set_emu_param script does not provide the ethernet interface FRUs
when the Ethernet interfaces are configured with VLAN.

Fix that by parsing "ifconfig" command accordingly.

RM #2706417