### PR TITLE
move ipmi_sim logs from emmc storage to tmpfs /run/log

### DIFF
--- a/debian/dirs
+++ b/debian/dirs
@@ -3,5 +3,3 @@ lib/systemd/system
 etc/ipmi
 var/ipmi_sim/mellanox
 etc/default
-var/log/set_emu_param
-var/log/mlx_ipmid

--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -11,8 +11,7 @@ install-data-local:
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/set_emu_param/"; \
+	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
@@ -33,8 +32,7 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
 	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
 	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
-	-rmdir "$(DESTDIR)$(localstatedir)/log/mlx_ipmid" 2>/dev/null
-	-rmdir "$(DESTDIR)$(localstatedir)/log/set_emu_param" 2>/dev/null
+	-rmdir "$(DESTDIR)/run/log/" 2>/dev/null
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null
 	-rmdir "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox" 2>/dev/null
 	-rmdir "$(DESTDIR)/lib/systemd/system" 2>/dev/null

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -508,8 +508,7 @@ install-data-local:
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/log/set_emu_param/"; \
+	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
@@ -530,8 +529,7 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
 	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
 	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
-	-rmdir "$(DESTDIR)$(localstatedir)/log/mlx_ipmid/"
-	-rmdir "$(DESTDIR)$(localstatedir)/log/set_emu_param/"
+	-rmdir "$(DESTDIR)/run/log/"
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null
 	-rmdir "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox" 2>/dev/null
 	-rmdir "$(DESTDIR)/lib/systemd/system" 2>/dev/null

--- a/lanserv/mellanox-bf/mlx_ipmid
+++ b/lanserv/mellanox-bf/mlx_ipmid
@@ -1,4 +1,4 @@
-/var/log/mlx_ipmid/mlx_ipmid.log {
+/run/log/mlx_ipmid.log {
         size 100k
         rotate 4
         missingok

--- a/lanserv/mellanox-bf/mlx_ipmid.conf
+++ b/lanserv/mellanox-bf/mlx_ipmid.conf
@@ -1,2 +1,2 @@
-if $programname == 'ipmi_sim' then /var/log/mlx_ipmid/mlx_ipmid.log
+if $programname == 'ipmi_sim' then /run/log/mlx_ipmid.log
 &stop

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -10,8 +10,8 @@ ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu
 Restart=always
 RestartSec=10
 TimeoutSec=60
-StandardOutput=append:/var/log/mlx_ipmid/mlx_ipmid.log
-StandardError=append:/var/log/mlx_ipmid/mlx_ipmid.log
+StandardOutput=append:/run/log/mlx_ipmid.log
+StandardError=append:/run/log/mlx_ipmid.log
 
 [Install]
 WantedBy=multi-user.target

--- a/lanserv/mellanox-bf/set_emu_param
+++ b/lanserv/mellanox-bf/set_emu_param
@@ -1,4 +1,4 @@
-/var/log/set_emu_param/set_emu_param.log {
+/run/log/set_emu_param.log {
         size 100k
         rotate 4
         missingok

--- a/lanserv/mellanox-bf/set_emu_param.conf
+++ b/lanserv/mellanox-bf/set_emu_param.conf
@@ -1,2 +1,2 @@
-if $programname == 'setipmi' then /var/log/set_emu_param/set_emu_param.log
+if $programname == 'setipmi' then /run/log/set_emu_param.log
 & stop

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -5,8 +5,8 @@ After=mlx_ipmid.service
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
 ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
-StandardOutput=append:/var/log/set_emu_param/set_emu_param.log
-StandardError=append:/var/log/set_emu_param/set_emu_param.log
+StandardOutput=append:/run/log/set_emu_param.log
+StandardError=append:/run/log/set_emu_param.log
 SyslogIdentifier=setipmi
 
 [Install]

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -96,8 +96,6 @@ make %{?_smp_mflags}
 /var/ipmi_sim/mellanox/sdr.30.main
 /lib/systemd/system/set_emu_param.service
 /lib/systemd/system/mlx_ipmid.service
-/var/log/mlx_ipmid
-/var/log/set_emu_param
 /etc/logrotate.d/mlx_ipmid
 /etc/logrotate.d/set_emu_param
 /etc/rsyslog.d/mlx_ipmid.conf


### PR DESCRIPTION
mlx_ipmid and set_emu_param can have multiple messages in their logs.
Dell/EMC is worried that it might wear out the emmc and requested to
move the logs to RAM instead. So the messages will be now logged to
/run/log/mlx_ipmid.log and /run/log/set_emu_param.log

RM #2750533