### PR TITLE
Support old systemd syntax

### DIFF
--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -5,6 +5,7 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 644 $(srcdir)/set_emu_param.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 644 $(srcdir)/sdr.30.main "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.lan.conf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
@@ -23,6 +24,7 @@ uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
+	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
 	-rm -f "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/sdr.30.main"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.lan.conf"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.emu"

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -502,6 +502,7 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 644 $(srcdir)/set_emu_param.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 644 $(srcdir)/sdr.30.main "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.lan.conf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
@@ -520,6 +521,7 @@ uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
+	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
 	-rm -f "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/sdr.30.main"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.lan.conf"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.emu"

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -5,13 +5,13 @@ Before=set_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStartPre=/bin/bash -c '/usr/bin/set_emu_param.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD}'
+ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD}'
 ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always
 RestartSec=10
 TimeoutSec=60
-StandardOutput=append:/run/log/mlx_ipmid.log
-StandardError=append:/run/log/mlx_ipmid.log
+StandardOutput=file:/run/log/mlx_ipmid.log
+StandardError=file:/run/log/mlx_ipmid.log
 
 [Install]
 WantedBy=multi-user.target

--- a/lanserv/mellanox-bf/mlx_ipmid_init.sh
+++ b/lanserv/mellanox-bf/mlx_ipmid_init.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+# This wrapper file is passed as ExecStartPre in
+# mlx_ipmid.service because the syntax:
+# StandardOutput=append:...
+# is only supported in systemd version >= 240.
+# Some linux distros (CentOS8.2 for example), support
+# older versions of systemd.
+# So use StandardOutput=file:...
+# The downside of this is that the whole log files
+# contents are overwritten each time the service is
+# restarted. The file needs to be deleted every time.
+
+# Arguments passed to this script:
+# $1 is set to "Bluewhale" if it is a BlueWhale board.
+# $2 should be set to 1 if IPMB is supported.
+# $3 should be set to the OOB ip address if supported.
+# example: "192.168.101.2". If OOB is not supported, $4
+# should be set to "0".
+# $4 should be set to 1 if external ddrs are supported.
+# $5 time interval for executing set_emu_param.sh in seconds.
+
+rm -f /run/log/mlx_ipmid.log
+/usr/bin/set_emu_param.sh $1 $2 $3 $4 $5

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -4,9 +4,10 @@ After=mlx_ipmid.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
+ExecStartPre=/bin/bash -c 'rm -f /run/log/set_emu_param.log'
 ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
-StandardOutput=append:/run/log/set_emu_param.log
-StandardError=append:/run/log/set_emu_param.log
+StandardOutput=file:/run/log/set_emu_param.log
+StandardError=file:/run/log/set_emu_param.log
 SyslogIdentifier=setipmi
 
 [Install]

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -89,6 +89,7 @@ make %{?_smp_mflags}
 %{_bindir}/ipmi*
 %{_bindir}/set_emu_param.sh
 %{_bindir}/poll_set_emu_param.sh
+%{_bindir}/mlx_ipmid_init.sh
 /usr/lib64/libOpen*
 /usr/lib64/libIPMI*
 /usr/lib64/pkgconfig/OpenIPMI*


### PR DESCRIPTION
The "append" keyword used in mlx_ipmid.service and set_emu_param.service
is not supported on the systemd version installed by default on
CentOS8.2. DellEMC would like to keep the default systemd
version so we need to use the "file" keyword instead.

"StandardOutput=append..." syntax only works in systemd 240 and newer.
After a restart of the service, the new logs are appended to the old logs.

"StandardOutput=file..." syntax works in systemd v236 and newer so it is
supported in CentOS8.2.
This limitation here is that the log files contents will be overwritten
each time the service restarts. And nothing will be logged after a service
restart until the log file is deleted.

RM #2796022