### PR TITLE
mlx-OpenIPMI.spec: Added provides list

### DIFF
--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -41,6 +41,9 @@ Source: %{_name}-%{_version}.tar.gz
 BuildRoot: %{?build_root:%{build_root}}%{!?build_root:/var/tmp/OFED}
 Vendor: Mellanox Technologies
 Requires: rasdaemon
+Provides: OpenIPMI
+Provides: OpenIPMI-libs
+Provides: OpenIPMI-modalias
 
 
 %description


### PR DESCRIPTION
ipmitool depends on in-box OpenIPMI packages that cannot be install due to conflicts with mlx-OpenIPMI.
mlx-OpenIPMI should claim that it provides the packages required by ipmitool to install it on CentOS.

RM #2923478

Signed-off-by: Vladimir Sokolovsky <vlad@nvidia.com>