### PR TITLE
Make the default LOOP_PERIOD=60

### DIFF
--- a/lanserv/mellanox-bf/progconf
+++ b/lanserv/mellanox-bf/progconf
@@ -1,5 +1,5 @@
 SUPPORT_IPMB="NONE"
 EXTERNAL_DDR="NO"
-LOOP_PERIOD=3
+LOOP_PERIOD=60
 BF_FAMILY=$(/usr/bin/bffamily | tr -d '[:space:]')
 OOB_IP="0"


### PR DESCRIPTION
We want to make the default LOOP_PERIOD=60 in the
yocto image.

RM #2934652