### PR TITLE
Fix missing QSFP EEPROM FRUs

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf.emu
+++ b/lanserv/mellanox-bf/mlx-bf.emu
@@ -63,12 +63,12 @@ sensor_add 0x30 0 6 0x01 0x01	\
 # QSFP port 0 link status
 sensor_add 0x30 0 7 0x1b 0x6f	\
 	poll 5000		\
-	file "/tmp/p0_link"
+	file "/run/emu_param/p0_link"
 
 # QSFP port 1 link status
 sensor_add 0x30 0 8 0x1b 0x6f	\
 	poll 5000		\
-	file "/tmp/p1_link"
+	file "/run/emu_param/p1_link"
 
 ########## FRUs ##########
 


### PR DESCRIPTION
The /tmp directory is not tmpfs on CentOS.
That means some of the supposedly temporary files stored in /tmp
are not deleted after a software reset and the logic to detect
link change could be erroneous. If someone removes a QSFP cable after
SW_RESET, this change will not take effect.
To fix this, write all the temporary files into the /run/emu_param
directory. The /run directory is tmpfs for all OS's.

RM #2935116