### PR TITLE
Fix collection of CEs and UEs

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -588,9 +588,11 @@ fi
 ###################
 # add trailing spaces to each line so that the dimms_ce_ue FRU can be updated
 # when the number of errors increases.
-
-ras-mc-ctl --error-count > $EMU_PARAM_DIR/dimms_ce_ue
-awk '{printf "%-100s\n", $0}' $EMU_PARAM_DIR/dimms_ce_ue > $EMU_PARAM_DIR/dimms_ce_ue
+if [ $(( $curr_time % 10 )) -eq 0 ]; then
+  ras-mc-ctl --error-count > $EMU_PARAM_DIR/ce_ue_tmp
+  { grep 'Label\|mc#0' $EMU_PARAM_DIR/ce_ue_tmp; grep -v 'Label\|mc#0' $EMU_PARAM_DIR/ce_ue_tmp; } > $EMU_PARAM_DIR/ce_ue_tmp1
+  awk '{printf "%-100s\n", $0}' $EMU_PARAM_DIR/ce_ue_tmp1 > $EMU_PARAM_DIR/dimms_ce_ue
+fi
 
 
 ###################################


### PR DESCRIPTION
ras-mc-ctl tool collects the data we need about CEs and UEs as
follows:
ras-mc-ctl --error-count
Label           CE      UE
mc#0slot#0      0       0
mc#1slot#0      0       0

But the way it displays data is not always in the same order.
When you run that command multiple times, it displays the data
as follows half of the time:
ras-mc-ctl --error-count
Label           CE      UE
mc#1slot#0      0       0
mc#0slot#0      0       0

The customer wants mc#0 to always be displayed first so that it
doesn't mess with their scripts.

So we added extra logic to always list the data in a particular
order starting mc#0 always.

I also took this opportunity to fix a bug introduced in my previous
commit: c8674e626cdc88daa9988ea131ec80852abde7db

RM #2950774