### PR TITLE
Increase timer for loading ipmb-host

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -103,9 +103,9 @@ if [ "$i2cbus" != "NONE" ]; then
 		   [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
 		   [ "$bffamily" = "Dell-Camelantis" ] || [ "$bffamily" = "Roy" ] ||
 		   [ "$bffamily" = "El-Dorado" ]; then
-			# Load the driver 2mn after boot to give the BMC time
+			# Load the driver 2.5mn after boot to give the BMC time
 			# to get ready for IPMB transactions.
-			if [ "$curr_time" -ge 120 ]; then
+			if [ "$curr_time" -ge 150 ]; then
 				modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
 				echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
 			fi


### PR DESCRIPTION
I have done some investigation and this is the generic expected
behavior from a linux open source standpoint:

the ipmb-host will try to do a handshake once at boot time and if
it fails because the BMC is not up, the user (QA/customer) will
have to unload/load it manually themselves.

In our case, after powercycle, the BMC takes ~2.5 more minutes to
boot than the BF, which is very large. If this timing increases
again in the future and we still have the requirement, we will
need to talk to the BMC team to take a look at their boot flow
or I will revert back to standard behavior. People will have
to load this driver manually.

In the past, some teams didn't want to do this manually so I
have added the set_emu_param.sh script that waits 2mn before
trying to load the driver. Once again this is not the standard
behavior. We should be loading the driver via ACPI table,
not via a script.

Recently, someone added code to the linux driver to retry loading
the driver 5 times over a period of 2.5 seconds. And then, if it
fails after those 2.5 seconds, same thing, the user has to load
it manually. so even if I port that latest linux code to our
5.4.60 kernel it is not going to be helpful because the BMC
takes 2.5 more minutes to boot than the BF.

For now, I will just increase the timer from 2mn to 2.5mn.

RM #2940690