### PR TITLE
Fix emmc_info size

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -694,6 +694,7 @@ if [ "$t" = "$fru_timer" ]; then
 	# Concatenate the binaries together
 	cat $EMU_PARAM_DIR/emmc_cid $EMU_PARAM_DIR/emmc_csd $EMU_PARAM_DIR/emmc_extcsd >> $EMU_PARAM_DIR/emmc_info
 
+	truncate -s 2000 $EMU_PARAM_DIR/emmc_info
 	wc -c $EMU_PARAM_DIR/emmc_info | cut -f 1 -d " " > $EMU_PARAM_DIR/emmc_info_filelen
 
 


### PR DESCRIPTION
The customer sees that although the emmc_info size matches the
emmc_info_filelen on the BF, the fru inventory of that FRU is
2 bytes off.
This is because the "use%", "available", "used" are all
susceptible to change during run time. So take that into account
and cap the emmc_info file size to an extra 500 characters.

RM #3010116