### PR TITLE
Fix the out of disk space caused by mlx_ipmid service log

### DIFF
--- a/lanserv/mellanox-bf/mlx_ipmid
+++ b/lanserv/mellanox-bf/mlx_ipmid
@@ -4,5 +4,7 @@
         missingok
         nodateext
         compress
-        copytruncate
+        postrotate
+                /bin/systemctl restart mlx_ipmid.service
+        endscript
 }


### PR DESCRIPTION
The logrotate for mlx_ipmid log is not working correctly. The size of the log will go back to the original size after rotated. So, it will become larger and larger.

Even though we truncate the file, the ipmi_sim writing to the file will continue writing at whichever offset it were at last. What's happening is that after the mlx_ipmid.log is truncated, the size of mlx_ipmid.log becomes zero and it is empty. Then the ipmi-sim will write to the log continually at the offset it left off. Finally, we get the mlx_ipmid log with NULL bytes up to the point where ipmi_sim truncated it plus the new entries written to the log.

To fix this, the log file should be opened in O_APPEND mode. So that the NULL bytes on the top of the log will be ignored, and new entries are written to the start of the file. Append mode has been introduced in systemd version 240. We can use that feature to make the log to be rotated correctly.

JIRA SDN-1772