### PR TITLE
Fix the out of disk space caused by mlx_ipmid service log

### DIFF
--- a/lanserv/mellanox-bf/mlx_ipmid
+++ b/lanserv/mellanox-bf/mlx_ipmid
@@ -4,7 +4,5 @@
         missingok
         nodateext
         compress
-        postrotate
-                /bin/systemctl restart mlx_ipmid.service
-        endscript
+        copytruncate
 }

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -10,8 +10,8 @@ ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu
 Restart=always
 RestartSec=10
 TimeoutSec=60
-StandardOutput=file:/run/log/mlx_ipmid.log
-StandardError=file:/run/log/mlx_ipmid.log
+StandardOutput=append:/run/log/mlx_ipmid.log
+StandardError=append:/run/log/mlx_ipmid.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The logrotate for mlx_ipmid log is working correctly. The size of the log will go back to the original size after rotated.

This is because even though we truncate the file, the ipmi_sim writing to the file will continue writing at whichever offset it were at last. So we get a mlx_ipmid log with NULL-bytes up to the point where ipmi_sim truncated it plus the new entries written to the log.

To fix this, the log file should be opened in O_APPEND mode. So that the NULL bytes on the top of the log will be ignored, and new entries are written to the start of the file. Append mode has been introduced in systemd version 240. We can use that feature to make the log to be rotated correctly.