### PR TITLE
 Fix the link status and Support the initialization of the product id

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf.emu
+++ b/lanserv/mellanox-bf/mlx-bf.emu
@@ -4,10 +4,24 @@
 # The BF's MC is at address 30
 mc_setbmc 0x30
 
+# Identify the platform ID and initialize the PRODUCT_ID accordingly where:
+# 0x3 – bluefield2 product id
+# 0x4 – bluefield3 product id
+BF2_PLATFORM_ID=0x00000214
+BF3_PLATFORM_ID=0x0000021c
+
+bfversion=$(bfhcafw mcra 0xf0014.0:16)
+
+if [ "$bfversion" = $BF2_PLATFORM_ID ]; then
+   productid=0x3
+elif  [ "$bfversion" = $BF3_PLATFORM_ID ]; then
+   productid=0x4
+fi
+
 # Add the MC
 # mc_add IPMBaddress DeviceID HasDeviceSDRs DeviceRevision MajorFWRev MinorFWRev
 # DeviceSupport ManufacturerID ProductID
-mc_add 0x30 0x30 no-device-sdrs 0x1 1 0 0x9f 0x8119 0x3 persist_sdr
+mc_add 0x30 0x30 no-device-sdrs 0x1 1 0 0x9f 0x8119 $productid  persist_sdr
 
 # sel_enable mc-addr max-entries flags
 sel_enable 0x30 1000 0x0a

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -70,7 +70,7 @@ elif [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ] ||
      [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
      [ "$bffamily" = "Dell-Camelantis" ] || [ "$bffamily" = "Roy" ] ||
      [ "$bffamily" = "El-Dorado" ] || [ "$bffamily" = "Moonraker" ] ||
-     [ "$bffamily" = "goldeneye" ]; then
+     [ "$bffamily" = "Goldeneye" ]; then
 	i2cbus=1
 else
 	i2cbus=$support_ipmb
@@ -100,7 +100,7 @@ if [ "$i2cbus" != "NONE" ]; then
 		   [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
 		   [ "$bffamily" = "Dell-Camelantis" ] || [ "$bffamily" = "Roy" ] ||
 		   [ "$bffamily" = "El-Dorado" ]  || [ "$bffamily" = "Moonraker" ] ||
-                   [ "$bffamily" = "goldeneye" ]; then
+                   [ "$bffamily" = "Goldeneye" ]; then
 			# Load the driver 2.5mn after boot to give the BMC time
 			# to get ready for IPMB transactions.
 			if [ "$curr_time" -ge 150 ]; then
@@ -448,8 +448,8 @@ else
 
 	if [ -s $EMU_PARAM_DIR/eth_bdfs.txt ]; then
 		while read bdf; do
-			link_status=$(cat /sys/bus/pci/devices/0000\:$bdf/net/*/operstate)
 			func=$(echo $bdf | cut -f 1 -d " " | cut -f 2 -d ".")
+			link_status=$(cat /sys/bus/pci/devices/0000\:$bdf/net/p$func/operstate)
 
 			if [ "$link_status" = "up" ]; then
 				if [ ! -f $EMU_PARAM_DIR/p$func"_link" ] || [ $(grep 2 $EMU_PARAM_DIR/p$func"_link") ]; then


### PR DESCRIPTION
Fix the link status for P0/p1_link sensor Ethernet interface
     In case of Ethernet interface the port link status is read
     from the /sys/bus/pci/devices/…/net/…/operstate, under
     the net not there are several devices. To initialize the link
     correctly we need to get the p0/1 status only.

Support the initialization of the product id according to the platform id
     get the platform ID and initialize the PRODUCT_ID accordingly where:
     0x3 – bluefield2 product id
     0x4 – bluefield3 product id
