### PR TITLE
OpenIPMI platform specific emu config file initialization

### DIFF
--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -6,10 +6,14 @@ install-data-local:
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/mlx_emu_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 644 $(srcdir)/set_emu_param.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 644 $(srcdir)/sdr.30.main "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.lan.conf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx-bf.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf-base.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf1.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf2.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf3.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
@@ -25,9 +29,13 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
+	-rm -f "$(DESTDIR)$(bindir)/mlx_emu_init.sh"
 	-rm -f "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/sdr.30.main"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.lan.conf"
-	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf-base.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf1.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf2.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-b3.emu"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/progconf"
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -503,10 +503,14 @@ install-data-local:
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/mlx_emu_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 644 $(srcdir)/set_emu_param.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 644 $(srcdir)/sdr.30.main "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf.lan.conf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx-bf.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf-base.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf1.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf2.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
+	$(INSTALL) -m 644 $(srcdir)/mlx-bf3.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
@@ -522,9 +526,13 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
+	-rm -f "$(DESTDIR)$(bindir)/mlx_emu_init.sh"
 	-rm -f "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/sdr.30.main"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.lan.conf"
-	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf-base.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf1.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf2.emu"
+	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf3.emu"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/progconf"
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
 	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"

--- a/lanserv/mellanox-bf/mlx-bf-base.emu
+++ b/lanserv/mellanox-bf/mlx-bf-base.emu
@@ -7,7 +7,7 @@ mc_setbmc 0x30
 # Add the MC
 # mc_add IPMBaddress DeviceID HasDeviceSDRs DeviceRevision MajorFWRev MinorFWRev
 # DeviceSupport ManufacturerID ProductID
-mc_add 0x30 0x30 no-device-sdrs 0x1 1 0 0x9f 0x8119 0x3 persist_sdr
+mc_add 0x30 0x30 no-device-sdrs 0x1 1 0 0x9f 0x8119 $PRODUCT_ID persist_sdr
 
 # sel_enable mc-addr max-entries flags
 sel_enable 0x30 1000 0x0a

--- a/lanserv/mellanox-bf/mlx-bf1.emu
+++ b/lanserv/mellanox-bf/mlx-bf1.emu
@@ -1,0 +1,6 @@
+# 
+# Emulation setup file for the Nvidia Bluefield1 DPU
+# 
+
+define PRODUCT_ID "0x2"
+include "mlx-bf-base.emu"

--- a/lanserv/mellanox-bf/mlx-bf2.emu
+++ b/lanserv/mellanox-bf/mlx-bf2.emu
@@ -1,0 +1,6 @@
+# 
+# Emulation setup file for the Nvidia Bluefield2 DPU
+# 
+
+define PRODUCT_ID "0x3"
+include "mlx-bf-base.emu"

--- a/lanserv/mellanox-bf/mlx-bf3.emu
+++ b/lanserv/mellanox-bf/mlx-bf3.emu
@@ -1,0 +1,6 @@
+# 
+# Emulation setup file for the Nvidia Bluefield23 DPU
+# 
+
+define PRODUCT_ID "0x4"
+include "mlx-bf-base.emu"

--- a/lanserv/mellanox-bf/mlx_emu_init.sh
+++ b/lanserv/mellanox-bf/mlx_emu_init.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+# Identify the platform ID and initialize the PRODUCT_ID accordingly where:
+# 0x3 – bluefield2 product id
+# 0x4 – bluefield3 product id
+BF1_PLATFORM_ID=0x00000211
+BF2_PLATFORM_ID=0x00000214
+BF3_PLATFORM_ID=0x0000021c
+
+bfversion=$(bfhcafw mcra 0xf0014.0:16)
+
+if [ "$bfversion" = $BF2_PLATFORM_ID ]; then
+   ln -sf /etc/ipmi/mlx-bf2.emu /etc/ipmi/mlx-bf.emu
+elif  [ "$bfversion" = $BF3_PLATFORM_ID ]; then
+   ln -sf /etc/ipmi/mlx-bf3.emu /etc/ipmi/mlx-bf.emu
+elif  [ "$bfversion" = $BF1_PLATFORM_ID ]; then
+   ln -sf /etc/ipmi/mlx-bf1.emu /etc/ipmi/mlx-bf.emu
+fi

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -6,6 +6,7 @@ Before=set_emu_param.service
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
 ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD}'
+ExecStartPre=/bin/bash -c '/usr/bin/mlx_emu_init.sh'
 ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always
 RestartSec=10


### PR DESCRIPTION
 In order to support per platform OpenIPMI emu configuration
 a base config file was created and each platform include the
 base config and set the platform specific parameters. In order
 to select the platform emu file additional preExecStart was
 added. This preExecStart identify the platform and create a
 symlink to teh platform config file.