### PR TITLE
Changing product name from Bluefield2 BMC to Bluefield2 ARM

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf3.emu
+++ b/lanserv/mellanox-bf/mlx-bf3.emu
@@ -2,5 +2,5 @@
 # Emulation setup file for the Nvidia Bluefield23 DPU
 #
 
-define PRODUCT_ID "0x4"
+define PRODUCT_ID "0x5"
 include "mlx-bf-base.emu"


### PR DESCRIPTION
Changing Product Name to ARM instead of BMC, by changing the Product ID
Test:
root@dpu-bmc:~# ipmitool -I ipmb mc info
Device ID                 : 48
Device Revision           : 1
Firmware Revision         : 1.00
IPMI Version              : 2.0
Manufacturer ID           : 33049
Manufacturer Name         : NVIDIA
Product ID                : 5 (0x0005)
Product Name              : Bluefield3 ARM
Device Available          : yes
Provides Device SDRs      : no
Additional Device Support :
    Sensor Device
    SDR Repository Device
    SEL Device
    FRU Inventory Device
    IPMB Event Receiver
    Chassis Device
Aux Firmware Rev Info     :
    0x00
    0x00
    0x00
    0x00

Fixes nvbuf https://redmine.mellanox.com/issues/3446162
Signed-off-by: Adi Fogel <afogel@nvidia.com>