### PR TITLE
Adding OEM handler - get system time

### DIFF
--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -1,3 +1,8 @@
+AM_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/lanserv
+pkglib_LTLIBRARIES = mellanox_bf_mod.la
+
+mellanox_bf_mod_la_SOURCES = mellanox_bf_mod.c
+mellanox_bf_mod_la_LDFLAGS = -module
 
 install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox/"; \

--- a/lanserv/mellanox-bf/mellanox_bf_mod.c
+++ b/lanserv/mellanox-bf/mellanox_bf_mod.c
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-3-Clause
+
+/* OEM handlers for Mellanox BlueField 
+ *
+ * Copyright (C) 2023 NVIDIA CORPORATION & AFFILIATES
+ * 
+ * This code is based on  Corey Minyard's /marvell-bmc/mervel_mod.c
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <OpenIPMI/ipmi_msgbits.h>
+#include <OpenIPMI/ipmi_bits.h>
+#include <OpenIPMI/serv.h>
+#include <lanserv/OpenIPMI/mcserv.h>
+#include <lanserv/bmc.h>
+
+#define PVERSION "1.0.1"
+#define IPMI_IANA_OEM_GET_SYSTEM_TIME_CMD	0x01
+
+/**************************************************************************
+ * Nvidia - Mellanox OEM commands.
+ *************************************************************************/
+
+/*
+* Handler for getting the DPU system time (real time - UTC) 
+*/
+static void ipmi_get_system_time(lmc_data_t    *mc,
+                                 msg_t         *msg,
+                                 unsigned char *rdata,
+                                 unsigned int  *rdata_len,
+                                 void          *cb_data)
+{
+    sys_data_t *sys = cb_data;
+    struct timeval t;
+
+    mc->emu->sysinfo->get_real_time(mc->emu->sysinfo, &t);        
+    rdata[0] = 0;
+    ipmi_set_uint32(rdata+1, t.tv_sec);
+    *rdata_len = 5;
+}
+
+int ipmi_sim_module_print_version(sys_data_t *sys, char *initstr)
+{
+    printf("IPMI Simulator Nvidia - Mellanox bf module version %s\n", PVERSION);
+    return 0;
+}
+
+/**************************************************************************
+ * Module initialization
+ *************************************************************************/
+
+int ipmi_sim_module_init(sys_data_t *sys, const char *initstr_i)
+{
+    int rv;
+
+    rv = ipmi_emu_register_iana_handler(IPMI_IANA_OEM_GET_SYSTEM_TIME_CMD,
+                ipmi_get_system_time, sys);
+    if (rv) {
+        sys->log(sys, OS_ERROR, NULL,
+            "Unable to register Mellanox IANA handler: %s", strerror(rv));
+    }
+
+    return 0;
+}
+
+int ipmi_sim_module_post_init(sys_data_t *sys)
+{
+    return 0;
+}

--- a/lanserv/mellanox-bf/mlx-bf.lan.conf
+++ b/lanserv/mellanox-bf/mlx-bf.lan.conf
@@ -37,3 +37,11 @@ set_working_mc 0x30
   user 1 true  ""        "test" user     10       none md2 md5 straight
   user 2 true  "ADMIN" 	 "ADMIN" admin    10       none md2 md5 straight
 
+# Dynamically load a module to extend the simulator.  After the module is
+# loaded, if the function "ipmi_sim_module_init" is defined in the module,
+# it will be called with the following parameters:
+#  int ipmi_sim_module_init(sys_data_t *sys, char *initstr);
+# where initstr is the init string passed on the module load line.
+# It should return 0 on success or an errno no failure.
+loadlib "/usr/lib64/OpenIPMI/mellanox_bf_mod.so" ""
+

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -105,6 +105,10 @@ make %{?_smp_mflags}
 /etc/logrotate.d/set_emu_param
 /etc/rsyslog.d/mlx_ipmid.conf
 /etc/rsyslog.d/set_emu_param.conf
+/usr/lib64/OpenIPMI/mellanox_bf_mod.a
+/usr/lib64/OpenIPMI/mellanox_bf_mod.so
+/usr/lib64/OpenIPMI/mellanox_bf_mod.so.0
+/usr/lib64/OpenIPMI/mellanox_bf_mod.so.0.0.0
 
 %changelog
 * Thu May 20 2021 Asmaa Mnebhi <asmaa@nvidia.com> - 2.0.25-3


### PR DESCRIPTION
Fixes nvbug https://redmine.mellanox.com/issues/3444628 Test:
fnFun = 0x2e (OEM command)
cmd = 1
data = 0x1 0x0 0x0 (iana commad number)
From BMC:
root@dpu-bmc:~# ipmitool -I ipmb raw 0x2e 1 0x1 0x0 0x0
 01 00 00 d9 4f 57 64