### PR TITLE
Fix the IPMB requests not working from BF to BMC

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -97,7 +97,7 @@ if [ "$i2cbus" != "NONE" ]; then
 	
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
-        if find /usr/lib/modules/ -name ipmb_host.ko -print -quit | grep -q .; then
+        if find /usr/lib/modules/ -name ipmb-host.ko -print -quit | grep -q .; then
 		is_ipmb_host_driver=true
         fi
         if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then


### PR DESCRIPTION
Wrong name of the ipmb host cause the ko is not loaded correctly after BF bootup. 
This commit fixes the typo.