### PR TITLE
Fix the IPMB requests not working from BF to BMC

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -97,7 +97,7 @@ if [ "$i2cbus" != "NONE" ]; then
 	
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
-        if find /usr/lib/modules/ -name ipmb_host.ko -print -quit | grep -q .; then
+        if find /usr/lib/modules/ -name ipmb*host.ko -print -quit | grep -q .; then
 		is_ipmb_host_driver=true
         fi
         if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then


### PR DESCRIPTION
The ko name of the ipmb host is compiled differently on different OS. 
It is ipmi_host.ko on Ubuntu and ipmi-host.ko on Anolis(DOCA_2.2.0_BSP_4.2.0_anolis_8.6-2.20230713.prod.bfb). 
Update the shell to make sure it can be found correctly.