### PR TITLE
Fix debian doesn't load ipmb-host

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -97,10 +97,11 @@ if [ "$i2cbus" != "NONE" ]; then
 	
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
-        if find /usr/lib/modules/ -name ipmb_host.ko -print -quit | grep -q .; then
+	
+    if find / -path "*/lib/modules/*" \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
 		is_ipmb_host_driver=true
-        fi
-        if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then
+    fi
+    if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then
 		if [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ] ||
 		   [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
 		   [ "$bffamily" = "Dell-Camelantis" ] || [ "$bffamily" = "Roy" ] ||


### PR DESCRIPTION
Fix debian doesn't load ipmb-host
Path on debian: /lib/modules/5.10.183-bf.11.g7356714/updates/ipmb-host.ko
Path on ubuntu: /usr/lib/modules/5.15.0-1014-bluefield/kernel/drivers/char/ipmi/ipmb_host.ko
Fix the find command, so it will match both distribution