### PR TITLE
Adding port ID to port lookup command, Eth mode.

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -233,7 +233,7 @@ get_connectx_net_info() {
 	# Make sure to parse out the VLAN interfaces as well. For ex: enp3s0f0np0.100
 	# Using 'ip -s link' command for consistency between different OSes
         get_port_info_cmd="ip -s link"
-        eth=$($get_port_info_cmd | grep -o "enp.*f.*:" | head -1 | awk -F: '{print $1}')
+        eth=$($get_port_info_cmd | grep -o "enp.*f$1.*:" | head -1 | awk -F: '{print $1}')
         if [ -z $eth ]; then
                 eth=$($get_port_info_cmd | grep -o "ib$1" | head -1)
 		if [ -z $eth ]; then


### PR DESCRIPTION
This fixes the bug that both ports have the same info, specifically MAC address.

Tested, on the setup the bug was detected:
```
dgxdev@romed8-2t-lab:~$ sudo curl --insecure -u "root:Nvidia_12345!" -H 'Content-Type: application/json' -X GET https://192.168.49.13/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/NetworkDeviceFunctions/eth0f0
{
  "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/NetworkDeviceFunctions/eth0f0",
  "@odata.type": "#NetworkDeviceFunction.v1_9_0.NetworkDeviceFunction",
  "Ethernet": {
    "MACAddress": "02:61:91:64:7b:e1",
    "MTUSize": 1500
  },
  "Id": "eth0f0",
  "Links": {
    "OffloadSystem": {
      "@odata.id": "/redfish/v1/Systems/Bluefield"
    },
    "PhysicalPortAssignment": {
      "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth0"
    }
  },
  "Name": "NetworkDeviceFunction",
  "NetDevFuncCapabilities": [
    "Ethernet"
  ],
  "NetDevFuncType": "Ethernet"
}dgxdev@romed8-2t-lab:~$ sudo curl --insecure -u "root:Nvidia_12345!" -H 'Content-Type: application/json' -X GET https://192.168.49.13/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/NetworkDeviceFunctions/eth1f0
{
  "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/NetworkDeviceFunctions/eth1f0",
  "@odata.type": "#NetworkDeviceFunction.v1_9_0.NetworkDeviceFunction",
  "Ethernet": {
    "MACAddress": "02:e1:e0:be:80:39",
    "MTUSize": 1500
  },
  "Id": "eth1f0",
  "Links": {
    "OffloadSystem": {
      "@odata.id": "/redfish/v1/Systems/Bluefield"
    },
    "PhysicalPortAssignment": {
      "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth1"
    }
  },
  "Name": "NetworkDeviceFunction",
  "NetDevFuncCapabilities": [
    "Ethernet"
  ],
  "NetDevFuncType": "Ethernet"
}dgxdev@romed8-2t-lab:~$


```

Fixes: https://redmine.mellanox.com/issues/3600004
