### PR TITLE
Fix mlx_ipmid and set_emu_paramm services not active

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -98,7 +98,7 @@ if [ "$i2cbus" != "NONE" ]; then
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
 	
-    if find / -path "*/lib/modules/*" \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
+    if find /lib/modules/ /usr/lib/modules/ \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
 		is_ipmb_host_driver=true
     fi
     if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then


### PR DESCRIPTION
When search the ipmb ko file in set_emu_param script, the starting-point of the find command shouldn't be set as root dictionary. This is because the root dictionary could have some redirect folder like "/mlnx/autodirect/" that is very large and stored in the remote system.

We should use explicit starting-point of the find command to search.

RM #3236339