### PR TITLE
Improve the IPMB connection between BMC and DPU

### DIFF
--- a/lanserv/mellanox-bf/mellanox_bf_mod.c
+++ b/lanserv/mellanox-bf/mellanox_bf_mod.c
@@ -15,6 +15,10 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
+#include <linux/module.h>
+#include <fcntl.h>
+#include <ctype.h>
 
 #include <OpenIPMI/ipmi_msgbits.h>
 #include <OpenIPMI/ipmi_bits.h>
@@ -22,17 +26,123 @@
 #include <lanserv/OpenIPMI/mcserv.h>
 #include <lanserv/bmc.h>
 
-#define PVERSION "1.0.1"
-#define IPMI_IANA_OEM_GET_SYSTEM_TIME_CMD	0x01
+#define PVERSION             "1.0.2"
+#define NVIDIA_IANA          5703
+#define GET_SYSTEM_TIME_CMD  1
+#define LOAD_IPMB_DRIVER_CMD 2
+
+#define IPMB_HOST_PATH           "modinfo ipmb_host --field filename"
+#define FLAG_PATH                "/run/emu_param/ipmb_host_driver_loaded"
+#define IPMB_HOST_PARAM          "slave_add=0x10"
+#define REGISTER_I2C_NEW_DEVICE  "echo ipmb-host 0x1011 > /sys/bus/i2c/devices/i2c-1/new_device"
+#define I2C_NEW_DEVICE           "/sys/bus/i2c/devices/i2c-1/1-1011/"
+
+#define init_module(module_image, len, param_values) syscall(__NR_init_module, module_image, len, param_values)
+#define delete_module(name, flags) syscall(__NR_delete_module, name, flags)
 
 /**************************************************************************
  * Nvidia - Mellanox OEM commands.
  *************************************************************************/
 
+/**
+ * Checks in /proc/modules whether a kernel module is loaded
+ *
+ * @param driver The name of the driver
+ * @return 1 if the module is loaded, 0 otherwise
+ */
+static int module_is_loaded(char *driver)
+{
+    /* use the same buffer length as lsmod */
+    char buffer[4096];
+    FILE * fmod = fopen("/proc/modules", "r");
+    int ret = 0;
+
+    int mod_len = strlen(driver);
+    if (mod_len > 4095) {
+        return 0;
+    }
+
+    if (!fmod) {
+        return 0;
+    }
+
+    while (fgets(buffer, sizeof(buffer), fmod)) {
+        if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
+            /* module is found */
+            ret = 1;
+            break;
+        }
+    }
+
+    fclose(fmod);
+    return ret;
+}
+
+/**
+ * Load the ipmb_host driver
+ *
+ * @return 1 if the ipmb_host is loaded successful, 0 otherwise
+ */
+static int load_ipmb_host_driver()
+{
+    int ret = 0;
+    int driver_fd, path_len;
+    size_t module_size;
+    struct stat st;
+    void *module;
+    char path_buffer[256];
+    FILE * fp;
+
+    /* ipmb_host is already loaded before the BMC booted up, need unload it first */
+    if (module_is_loaded("ipmb_host") == 1) {
+        if (delete_module("ipmb_host", O_NONBLOCK) != 0) {
+            return ret;
+        }
+    }
+
+    /* Read the path of ipmb_host driver file*/
+    fp = popen(IPMB_HOST_PATH, "r");
+    if (!fp) {
+        return ret;
+    }
+    fgets(path_buffer, sizeof(path_buffer), fp);
+    pclose(fp);
+    path_len = strlen(path_buffer);
+    path_buffer[path_len-1] = '\0';
+
+    /* Start loading the driver */
+    driver_fd = open(path_buffer, O_RDONLY);
+    if (driver_fd < 0) {
+        return ret;
+    }
+    fstat(driver_fd, &st);
+    module_size = st.st_size;
+    module = malloc(module_size);
+    if(!module) {
+        return ret;
+    }
+    read(driver_fd, module, module_size);
+    close(driver_fd);
+    if (init_module(module, module_size, IPMB_HOST_PARAM) != 0) {
+        free(module);
+        return ret;
+    }
+    free(module);
+
+    /* Register the new I2C device if not exist*/
+    if (access(I2C_NEW_DEVICE, F_OK) != 0) {
+        if (system(REGISTER_I2C_NEW_DEVICE) == -1) {
+            return ret;
+        }
+    }
+    ret = 1;
+    return ret;
+}
+
 /*
-* Handler for getting the DPU system time (real time - UTC) 
+* Handler for getting the DPU system time (real time - UTC)
 */
-static void ipmi_get_system_time(lmc_data_t    *mc,
+static void handle_oem_command(lmc_data_t    *mc,
                                  msg_t         *msg,
                                  unsigned char *rdata,
                                  unsigned int  *rdata_len,
@@ -40,11 +150,52 @@ static void ipmi_get_system_time(lmc_data_t    *mc,
 {
     sys_data_t *sys = cb_data;
     struct timeval t;
+    int flag_fd;
 
-    mc->emu->sysinfo->get_real_time(mc->emu->sysinfo, &t);        
-    rdata[0] = 0;
-    ipmi_set_uint32(rdata+1, t.tv_sec);
-    *rdata_len = 5;
+    switch (msg->cmd) {
+    case GET_SYSTEM_TIME_CMD:
+    {
+        rdata[0] = 0;
+        mc->emu->sysinfo->get_real_time(mc->emu->sysinfo, &t);
+        ipmi_set_uint32(rdata+1, t.tv_sec);
+        *rdata_len = 5;
+    }
+    break;
+
+    case LOAD_IPMB_DRIVER_CMD:
+    {
+        rdata[0] = 0x0;
+        *rdata_len = 2;
+
+        /* If flag exists, driver don't need to be reloaded again */
+        if (access(FLAG_PATH, F_OK) == 0) {
+            rdata[1] = 0x2;
+            return;
+        }
+
+        /* Create a flag to indicate that the handler tried to load ipmb_host driver */
+        flag_fd = open(FLAG_PATH, O_RDWR | O_CREAT, S_IRUSR | S_IRGRP | S_IROTH);
+        if (flag_fd < 0) {
+            rdata[1] = 0x0;
+            return;
+        }
+
+        /* Load the ipmb_host driver */
+        /* Return 1 if the driver is loaded successful, 0 otherwise */
+        if (load_ipmb_host_driver() == 1) {
+            rdata[1] = 0x1;
+        } else {
+            rdata[1] = 0x0;
+        }
+    }
+    break;
+
+    default:
+        handle_invalid_cmd(mc, rdata, rdata_len);
+    break;
+    }
+
+    return;
 }
 
 int ipmi_sim_module_print_version(sys_data_t *sys, char *initstr)
@@ -61,8 +212,8 @@ int ipmi_sim_module_init(sys_data_t *sys, const char *initstr_i)
 {
     int rv;
 
-    rv = ipmi_emu_register_iana_handler(IPMI_IANA_OEM_GET_SYSTEM_TIME_CMD,
-                ipmi_get_system_time, sys);
+    rv = ipmi_emu_register_iana_handler(NVIDIA_IANA,
+                handle_oem_command, sys);
     if (rv) {
         sys->log(sys, OS_ERROR, NULL,
             "Unable to register Mellanox IANA handler: %s", strerror(rv));

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -5,7 +5,7 @@ Before=set_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD}'
+ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD} ${BF_VERSION}'
 ExecStartPre=/bin/bash -c '/usr/bin/mlx_emu_init.sh'
 ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always

--- a/lanserv/mellanox-bf/mlx_ipmid_init.sh
+++ b/lanserv/mellanox-bf/mlx_ipmid_init.sh
@@ -21,4 +21,4 @@
 # $5 time interval for executing set_emu_param.sh in seconds.
 
 rm -f /run/log/mlx_ipmid.log
-/usr/bin/set_emu_param.sh $1 $2 $3 $4 $5
+/usr/bin/set_emu_param.sh $1 $2 $3 $4 $5 $6

--- a/lanserv/mellanox-bf/poll_set_emu_param.sh
+++ b/lanserv/mellanox-bf/poll_set_emu_param.sh
@@ -7,8 +7,10 @@
 # $4 should be set to the OOB ip address if supported.
 # example: "192.168.101.2". If OOB is not supported, $4
 # should be set to "0".
+# $6 is set to the Bluefield Platfrom ID.
+# example: "0x0000021c" for Bluefield-3.
 
 while /bin/true; do
-	/usr/bin/set_emu_param.sh $2 $3 $4 $5 $1
+	/usr/bin/set_emu_param.sh $2 $3 $4 $5 $1 $6
 	sleep $1
 done

--- a/lanserv/mellanox-bf/progconf
+++ b/lanserv/mellanox-bf/progconf
@@ -2,4 +2,5 @@ SUPPORT_IPMB="NONE"
 EXTERNAL_DDR="NO"
 LOOP_PERIOD=60
 BF_FAMILY=$(/usr/bin/bffamily | tr -d '[:space:]')
+BF_VERSION=$(bfhcafw mcra 0xf0014.0:16)
 OOB_IP="0"

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -5,7 +5,7 @@ After=mlx_ipmid.service
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
 ExecStartPre=/bin/bash -c 'rm -f /run/log/set_emu_param.log'
-ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR}'
+ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${BF_VERSION}'
 StandardOutput=file:/run/log/set_emu_param.log
 StandardError=file:/run/log/set_emu_param.log
 SyslogIdentifier=setipmi


### PR DESCRIPTION
This feature is to improve the IPMB connection time between BMC and DPU. When BMC is booting up, it sends specific IPMI OEM command to DPU as a notification, so the DPU can know the BMC is ready, and load ipmb-host driver. This feature is only for Bluefield-3 currently.

1. Remove the 150s delay for all Bluefield-3. Normally, BMC is faster than DPU on BF3 to start IPMB service, and can handle the message from DPU, so the handshake in ipmb_host can be successful.
2. New IPMI OEM command is implemented in the OpenIPMI OEM handler. This command handler is used to receive the notification from BMC to DPU. When OEM handler receives this command from BMC, it will check the status of the ipmb-host driver, and reload the ipmb-host if needed.
3. Change the IANA number from 1 to 5703, which is the IANA for Nvidia.

RM: 3631288