### PR TITLE
Change ip command back to ifconfig for release compatibility.

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -269,9 +269,8 @@ get_connectx_net_info() {
 	fi
 
 	echo "LAN Interface:" > $EMU_PARAM_DIR/eth$1
-	if ip link show dev $eth >> $EMU_PARAM_DIR/eth$1 2>/dev/null; then
-		sed -i 's/^[0-9]*: //' $EMU_PARAM_DIR/eth$1
-	else
+	ifconfig $eth >> $EMU_PARAM_DIR/eth$1 2>/dev/null
+	if [ ! $? -eq 0 ]; then
 		# if this interface is not supported, update FRU file NA
 		echo "NA" > $EMU_PARAM_DIR/eth$1
 


### PR DESCRIPTION
Changing how we parse port info- from 'ip' back to 'ifconfig' for correct LinkStatus and Speed info for the release.

This change reverts the change from this PR: https://github.com/Mellanox/mlx-OpenIPMI/pull/71

Tested:
// BF2, Eth mode:

```
-X GET https://10.237.41.247/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth0
{
  "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth0",
  "@odata.type": "#Port.v1_6_0.Port",
  "CurrentSpeedGbps": 25,
  "Id": "eth0",
  "LinkNetworkTechnology": "Ethernet",
  "LinkStatus": "LinkUp",
  "Name": "Port"
}
```

```
-X GET https://10.237.41.247/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth1
{
  "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth1",
  "@odata.type": "#Port.v1_6_0.Port",
  "CurrentSpeedGbps": 25,
  "Id": "eth1",
  "LinkNetworkTechnology": "Ethernet",
  "LinkStatus": "LinkUp",
  "Name": "Port"
}
```


```
root@dpu-bmc:~# busctl introspect xyz.openbmc_project.Settings.dpu_eth /xyz/openbmc_project/network/host0/eth0
NAME                                          TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable           interface -         -                                        -
.Introspect                                   method    -         s                                        -
org.freedesktop.DBus.Peer                     interface -         -                                        -
.GetMachineId                                 method    -         s                                        -
.Ping                                         method    -         -                                        -
org.freedesktop.DBus.Properties               interface -         -                                        -
.Get                                          method    ss        v                                        -
.GetAll                                       method    s         a{sv}                                    -
.Set                                          method    ssv       -                                        -
.PropertiesChanged                            signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.EthernetInterface interface -         -                                        -
.AutoNeg                                      property  b         false                                    emits-change
.DHCPEnabled                                  property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.DefaultGateway                               property  s         ""                                       emits-change writable
.DefaultGateway6                              property  s         ""                                       emits-change writable
.DomainName                                   property  as        0                                        emits-change writable
.IPv6AcceptRA                                 property  b         false                                    emits-change writable
.InterfaceName                                property  s         "enp3s0f0s0"                             const
.LinkLocalAutoConf                            property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.LinkUp                                       property  b         true                                     emits-change
.MTU                                          property  u         1500                                     emits-change writable
.NICEnabled                                   property  b         false                                    emits-change writable
.NTPServers                                   property  as        0                                        emits-change writable
.Nameservers                                  property  as        0                                        emits-change writable
.Speed                                        property  u         25000                                    emits-change
.StaticNTPServers                             property  as        0                                        emits-change writable
.StaticNameServers                            property  as        0                                        emits-change writable
xyz.openbmc_project.Network.MACAddress        interface -         -                                        -
.MACAddress                                   property  s         "02:2b:04:62:30:8f"                      emits-change writable
```

```
root@dpu-bmc:~# busctl introspect xyz.openbmc_project.Settings.dpu_eth /xyz/openbmc_project/network/host0/eth1
NAME                                          TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable           interface -         -                                        -
.Introspect                                   method    -         s                                        -
org.freedesktop.DBus.Peer                     interface -         -                                        -
.GetMachineId                                 method    -         s                                        -
.Ping                                         method    -         -                                        -
org.freedesktop.DBus.Properties               interface -         -                                        -
.Get                                          method    ss        v                                        -
.GetAll                                       method    s         a{sv}                                    -
.Set                                          method    ssv       -                                        -
.PropertiesChanged                            signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.EthernetInterface interface -         -                                        -
.AutoNeg                                      property  b         false                                    emits-change
.DHCPEnabled                                  property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.DefaultGateway                               property  s         ""                                       emits-change writable
.DefaultGateway6                              property  s         ""                                       emits-change writable
.DomainName                                   property  as        0                                        emits-change writable
.IPv6AcceptRA                                 property  b         false                                    emits-change writable
.InterfaceName                                property  s         "enp3s0f1s0"                             const
.LinkLocalAutoConf                            property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.LinkUp                                       property  b         true                                     emits-change
.MTU                                          property  u         1500                                     emits-change writable
.NICEnabled                                   property  b         false                                    emits-change writable
.NTPServers                                   property  as        0                                        emits-change writable
.Nameservers                                  property  as        0                                        emits-change writable
.Speed                                        property  u         25000                                    emits-change
.StaticNTPServers                             property  as        0                                        emits-change writable
.StaticNameServers                            property  as        0                                        emits-change writable
xyz.openbmc_project.Network.MACAddress        interface -         -                                        -
.MACAddress                                   property  s         "02:10:80:ec:ff:ef"                      emits-change writable
root@dpu-bmc:~#

```
