### PR TITLE
Adjust cpuinfo fru size to fit larger lscpu files

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf-base.emu
+++ b/lanserv/mellanox-bf/mlx-bf-base.emu
@@ -99,7 +99,7 @@ sensor_add 0x30 0 8 0x1b 0x6f	\
 mc_add_fru_data 0x30 0 6 file 0 "/run/emu_param/ipmb_update_timer"
 mc_add_fru_data 0x30 1 2000 file 0 "/run/emu_param/fw_info"
 mc_add_fru_data 0x30 2 100 file 0 "/run/emu_param/nic_pci_dev_info"
-mc_add_fru_data 0x30 3 5900 file 0 "/run/emu_param/cpuinfo"
+mc_add_fru_data 0x30 3 6200 file 0 "/run/emu_param/cpuinfo"
 mc_add_fru_data 0x30 4 512 file 0 "/run/emu_param/ddr0_0_spd"
 mc_add_fru_data 0x30 5 512 file 0 "/run/emu_param/ddr0_1_spd"
 mc_add_fru_data 0x30 6 512 file 0 "/run/emu_param/ddr1_0_spd"

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -632,7 +632,7 @@ if [ "$t" = "$fru_timer" ]; then
 	###################################
 	lscpu > $EMU_PARAM_DIR/cpuinfo
 	cat /proc/cpuinfo >> $EMU_PARAM_DIR/cpuinfo
-	truncate -s 5900 $EMU_PARAM_DIR/cpuinfo
+	truncate -s 6200 $EMU_PARAM_DIR/cpuinfo
 
 
 	##########################################


### PR DESCRIPTION
The previous value was not enough for some lscpu outputs.

Fixes nvbug https://redmine.mellanox.com/issues/3715057