### PR TITLE
Fix minor bugs

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf-base.emu
+++ b/lanserv/mellanox-bf/mlx-bf-base.emu
@@ -98,7 +98,7 @@ sensor_add 0x30 0 8 0x1b 0x6f	\
 
 mc_add_fru_data 0x30 0 6 file 0 "/run/emu_param/ipmb_update_timer"
 mc_add_fru_data 0x30 1 2000 file 0 "/run/emu_param/fw_info"
-mc_add_fru_data 0x30 2 100 file 0 "/run/emu_param/nic_pci_dev_info"
+mc_add_fru_data 0x30 2 200 file 0 "/run/emu_param/nic_pci_dev_info"
 mc_add_fru_data 0x30 3 6200 file 0 "/run/emu_param/cpuinfo"
 mc_add_fru_data 0x30 4 512 file 0 "/run/emu_param/ddr0_0_spd"
 mc_add_fru_data 0x30 5 512 file 0 "/run/emu_param/ddr0_1_spd"

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -510,7 +510,7 @@ else
 	lspci -n -v -m -s $bdf_eth > $EMU_PARAM_DIR/nic_pci_dev_info 2>/dev/null
 	lspci -n -v -m -s $bdf_ib >> $EMU_PARAM_DIR/nic_pci_dev_info 2>/dev/null
 
-	truncate -s 100 $EMU_PARAM_DIR/nic_pci_dev_info
+	truncate -s 200 $EMU_PARAM_DIR/nic_pci_dev_info
 
 	update_cables_info $EMU_PARAM_DIR/eth_bdfs.txt
 	update_cables_info $EMU_PARAM_DIR/ib_bdfs.txt
@@ -533,19 +533,11 @@ get_fw_info() {
 	BlueField OFED Version: $(ofed_info -s | sed 's/.$//')
 	EOF
 
-	if [ $bdf_eth ]; then
-		cat <<- EOF >> $EMU_PARAM_DIR/fw_info
-		vpd info:
-		$(lspci -vvv -s $bdf_eth | sed -n "/Vital/,/End/p")
-		EOF
-	elif [ $bdf_ib ]; then
-		cat <<- EOF >> $EMU_PARAM_DIR/fw_info
-		vpd info:
-		$(lspci -vvv -s $bdf_ib | sed -n "/Vital/,/End/p")
-		EOF
-	else
-		echo "Unable to get VPD info" >> $EMU_PARAM_DIR/fw_info
-	fi
+	# Get VPD info
+	cat <<- EOF >> $EMU_PARAM_DIR/fw_info
+	vpd info:
+	$(mlxvpd -d /dev/mst/mt*_pciconf0)
+	EOF
 
 	if [ -d /sys/class/infiniband/mlx*_0 ]; then
 		port=0


### PR DESCRIPTION
Increasing nic_pci_dev_info FRU to handle cases where dual port board has both Eth and IB configured.

Taking VPD now via dedicated tool, without depending on PCI setup.

Tested:
```
root@dpu-bmc:~# ipmitool -I ipmb fru read 1 f1
Fru Size         : 2000 bytes
Done
root@dpu-bmc:~# cat f1
BlueField ATF version: v2.2(release):4.5.0-37-g8408d48
BlueField UEFI version: 4.5.0-43-geb17a52
BlueField BSP version: 4.5.0.12987

OS Release Version: DOCA_2.5.0_BSP_4.5.0_Ubuntu_22.04-1.20231205.dev
BlueField OFED Version: MLNX_OFED_LINUX-23.10-1.1.9.0
vpd info:

  VPD-KEYWORD    DESCRIPTION             VALUE
  -----------    -----------             -----
Read Only Section:

  PN             Part Number             900-9D3B4-00EN-EAA
  EC             Revision                A9
  V2             N/A                     900-9D3B4-00EN-EAA
  SN             Serial Number           MT2329XZ0112
  V3             N/A                     b80e9b3d2235ee118000a088c20e8790
  VA             N/A                     MLX:MN=MLNX:CSKU=V2:UUID=V3:PCI=V0:MODL=D3B4
  V0             Misc Info               PCIeGen5 x16
  VU             N/A                     MT2329XZ0112ECMLNXS0D0F0
  RV             Checksum Complement     0xfd
  IDTAG          Board Id                BlueField-3 E-series DPU NDR/400GbE VPI single port QSFP112, PCIe Gen5.0 x16 FHHL, Crypto Enabled, 16GB on board DDR, BMC, Tall Bracket, IPN DK
connectx_fw_ver: 32.39.2048
board_id: MT_0000001033
node_guid: a088:c203:000e:8798
sys_image_guid: a088:c203:000e:8790
root@dpu-bmc:~#
```

```
root@dpu-bmc:~# ipmitool -I ipmb fru read 2 f2
Fru Size         : 200 bytes
Done
root@dpu-bmc:~# cat f2
Device: 03:00.0
Class:  0207
Vendor: 15b3
Device: a2dc
SVendor:        15b3
SDevice:        0016
Rev:    01
IOMMUGroup:     7

root@dpu-bmc:~#

```


Fixes https://redmine.mellanox.com/issues/3753149 and https://redmine.mellanox.com/issues/3753164