### PR TITLE
Add InterfaceEnabled from Network Manager to FRU

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -231,6 +231,19 @@ update_cables_info()
 	fi
 }
 
+# Getting Link Interface data using nmcli command.
+get_port_data() {
+    port_name="$1"
+    file_index="$2"  
+    file_name="$3"
+    file_path="$EMU_PARAM_DIR/$file_name$file_index"
+
+    # Fetch the device's connected/unmanaged status and prepare the message
+    status_line=$(nmcli -t -f DEVICE,STATE device status | grep "$port_name")
+
+    echo "$status_line" >> "$file_path"
+}
+
 ##########################################################
 # Get connectX network interfaces information            #
 #                                                        #
@@ -292,6 +305,7 @@ get_connectx_net_info() {
 		truncate -s 3200 $EMU_PARAM_DIR/$file_name$1
 		return
 	fi
+	get_port_data "$eth" "$1" "$file_name"
 	ethtool $eth | grep -i "speed" >> $EMU_PARAM_DIR/$file_name$1
 
 	# Get gateway


### PR DESCRIPTION
To tell if a link/port has it's interface enabled, we will check using nmcli command (Network Manager), then push it to the relevant port's FRU.

In dpu-manager it will be used to update the property NICEnabled.

Tested:

FRU:

```
root@dpu-bmc:~# ipmitool -I ipmb fru read 17 f17
Fru Size         : 3200 bytes
Done
root@dpu-bmc:~# cat f17
LAN Interface:
oob_net0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.245.41.97  netmask 255.255.240.0  broadcast 10.245.47.255
        inet6 fe80::a288:c2ff:fe0e:87a4  prefixlen 64  scopeid 0x20<link>
        ether a0:88:c2:0e:87:a4  txqueuelen 1000  (Ethernet)
        RX packets 2098  bytes 231864 (231.8 KB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 139  bytes 12853 (12.8 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

oob_net0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether a0:88:c2:0e:87:a4 brd ff:ff:ff:ff:ff:ff
    altname enamlnxbf17i0
oob_net0:connected
        Speed: 1000Mb/s
default via 10.245.32.1 dev oob_net0 proto dhcp metric 101
IPv4 Address Origin: Static
End LAN Interface
root@dpu-bmc:~#

```
DBUS Object:

```
root@dpu-bmc:~# busctl introspect xyz.openbmc_project.Settings.dpu_eth /xyz/openbmc_project/network/host0/oob0
NAME                                          TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.freedesktop.DBus.Introspectable           interface -         -                                        -
.Introspect                                   method    -         s                                        -
org.freedesktop.DBus.Peer                     interface -         -                                        -
.GetMachineId                                 method    -         s                                        -
.Ping                                         method    -         -                                        -
org.freedesktop.DBus.Properties               interface -         -                                        -
.Get                                          method    ss        v                                        -
.GetAll                                       method    s         a{sv}                                    -
.Set                                          method    ssv       -                                        -
.PropertiesChanged                            signal    sa{sv}as  -                                        -
xyz.openbmc_project.Network.EthernetInterface interface -         -                                        -
.AutoNeg                                      property  b         false                                    emits-change
.DHCP4                                        property  b         false                                    emits-change writable
.DHCP6                                        property  b         false                                    emits-change writable
.DHCPEnabled                                  property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.DefaultGateway                               property  s         ""                                       emits-change writable
.DefaultGateway6                              property  s         ""                                       emits-change writable
.DomainName                                   property  as        0                                        emits-change writable
.IPv6AcceptRA                                 property  b         false                                    emits-change writable
.InterfaceName                                property  s         "oob_net0"                               const
.LinkLocalAutoConf                            property  s         "xyz.openbmc_project.Network.Ethernet... emits-change writable
.LinkUp                                       property  b         true                                     emits-change
.MTU                                          property  u         1500                                     emits-change writable
/*Updated Property*/ .NICEnabled                                   property  b         true                                     emits-change writable
.NTPServers                                   property  as        0                                        emits-change writable
.Nameservers                                  property  as        0                                        emits-change
.Speed                                        property  u         1000                                     emits-change
.StaticNTPServers                             property  as        0                                        emits-change writable
.StaticNameServers                            property  as        0                                        emits-change writable
xyz.openbmc_project.Network.LinkType          interface -         -                                        -
.LinkType                                     property  s         "xyz.openbmc_project.Network.LinkType... emits-change
xyz.openbmc_project.Network.MACAddress        interface -         -                                        -
.MACAddress                                   property  s         "a0:88:c2:0e:87:a4"                      emits-change writable
```

Fixes https://redmine.mellanox.com/issues/3826493
