### PR TITLE
Cherry pick commit 7e23fd6f7a62ef0c84c84689596fed69e8bdc328 from main

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -260,6 +260,8 @@ get_connectx_net_info() {
 	fi
 
 	echo "LAN Interface:" > $EMU_PARAM_DIR/eth$1
+	ifconfig $eth >> $EMU_PARAM_DIR/eth$1 2>/dev/null
+	# Getting output from both ifconfig and ip for compatibility with older BMC versions
 	if ip link show dev $eth >> $EMU_PARAM_DIR/eth$1 2>/dev/null; then
 		sed -i 's/^[0-9]*: //' $EMU_PARAM_DIR/eth$1
 	else


### PR DESCRIPTION
Pick commit 7e23fd6f7a62ef0c84c84689596fed69e8bdc328 from main for compatibility with all BMC versions

Tested on June LTS version: 
```
[15:49:21] alapidus@dev-platform-6: /images $ curl -k -H "X-Auth-Token: $token" -H 'Content-Type: application/json' -X GET https://${bmc}/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth0
{
  "@odata.id": "/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports/eth0",
  "@odata.type": "#Port.v1_6_0.Port",
  "CurrentSpeedGbps": 25,
  "Id": "eth0",
  "LinkNetworkTechnology": "Ethernet",
  "LinkStatus": "LinkUp",
  "Name": "Port"
}
```