### PR TITLE
Creating the dmidecode file every set emu cycle

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -847,13 +847,15 @@ fi
 ###################################
 #        Get the dmidecode_info   #
 ###################################
-if [ ! -f "$EMU_PARAM_DIR/dmidecode_info" ] && [ -n "$product_name" ]; then
+#This is done every one minute due to error when instaling new bfb
+if  [ -n "$product_name" ]; then
+	rm $EMU_PARAM_DIR/dmidecode_info
 	declare -A fruConf
 	source /etc/ipmi/config_type.sh
 	for key in "${!fruConf[@]}"; do
 		output=$(dmidecode -s ${fruConf[$key]})
 		echo "$key : $output" >> $EMU_PARAM_DIR/dmidecode_info
 	done
-	
+
 	truncate -s 700 $EMU_PARAM_DIR/dmidecode_info
 fi


### PR DESCRIPTION
In case of bfb install, the dmidecode is created empty. To solve this issue, the file will be created in every cycle of the set-emu-param.