### PR TITLE
Enhance IPMB host loading with retry mechanism to avoid the driver crash

### DIFF
--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -18,6 +18,7 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/load_ipmb_host.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_emu_init.sh "$(DESTDIR)$(bindir)/"; \
@@ -43,6 +44,7 @@ install-data-local:
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
+	-rm -f "$(DESTDIR)$(bindir)/load_ipmb_host.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_emu_init.sh"

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -734,6 +734,7 @@ install-data-local:
 	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 -d "$(DESTDIR)/lib/systemd/system/"; \
 	$(INSTALL) -m 755 $(srcdir)/set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
+	$(INSTALL) -m 755 $(srcdir)/load_ipmb_host.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/poll_set_emu_param.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_ipmid_init.sh "$(DESTDIR)$(bindir)/"; \
 	$(INSTALL) -m 755 $(srcdir)/mlx_emu_init.sh "$(DESTDIR)$(bindir)/"; \
@@ -757,6 +758,7 @@ install-data-local:
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
 	-rm -f "$(DESTDIR)$(bindir)/set_emu_param.sh"
+	-rm -f "$(DESTDIR)$(bindir)/load_ipmb_host.sh"
 	-rm -f "$(DESTDIR)$(bindir)/poll_set_emu_param.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_ipmid_init.sh"
 	-rm -f "$(DESTDIR)$(bindir)/mlx_emu_init.sh"

--- a/lanserv/mellanox-bf/load_ipmb_host.sh
+++ b/lanserv/mellanox-bf/load_ipmb_host.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Check if the i2cbus parameter is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <i2cbus>"
+  exit 1
+fi
+
+i2cbus=$1
+
+# By default, 0x11 is the BF slave address at which
+# the ipmb_host device is registered.
+# The i2c slave backends have their own address
+# space. So, add 0x1000 to the original address.
+# The following addresses are all in hex.
+IPMB_HOST_ADD=0x1011
+
+# By default, the ipmb_host driver communicates with
+# a client at address 0x10.
+# ipmb_host driver is not installed in all images
+IPMB_HOST_CLIENTADDR=0x10
+
+I2C_NEW_DEV=/sys/bus/i2c/devices/i2c-$i2cbus/new_device
+I2C_DEL_DEV=/sys/bus/i2c/devices/i2c-$i2cbus/delete_device
+# The IPMB_HOST_FLAG is created if the ipmb-host driver is loaded by the BMC
+# using ipmi oem command: ipmitool -I ipmb raw 0x2e 0x2 0x47 0x16 0x0
+# This flag is cleared after reboot the DPU.
+IPMB_HOST_FLAG=/run/emu_param/ipmb_host_driver_loaded
+# The IPMB_RETRY_FLAG is created if the host driver is needed to be reloaded.
+# This flag is cleared after reboot the DPU or successful retry.
+IPMB_RETRY_FLAG=/run/emu_param/ipmb_host_driver_retry
+# Define the retry interval increase every one minute
+
+load_ipmb_host() {
+	modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
+	echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+}
+
+remove_ipmb_host() {
+	echo $IPMB_HOST_ADD > $I2C_DEL_DEV
+	rmmod ipmb_host
+}
+
+check_ipmb_connection() {
+	# Check IPMI MC info and redirect output to /dev/null
+	ipmitool mc info > /dev/null 2>&1
+	# If ipmitool command fails
+	if [ $? -ne 0 ]; then
+		# If IPMB retry flag file exists, read and increment the retry count
+		if [ -f $IPMB_RETRY_FLAG ]; then
+			retries=$(cat $IPMB_RETRY_FLAG)
+			retries=$((retries + 1))
+		else
+		# If the file does not exist, start with the first retry
+			retries=1
+		fi
+        # Update the retry count in the file
+		echo $retries > $IPMB_RETRY_FLAG
+		remove_ipmb_host
+	else
+		# Remove IPMB retry flag file if ipmitool command succeeds
+		rm -f $IPMB_RETRY_FLAG
+	fi
+}
+
+# Function to load IPMB host with retry mechanism
+if [ ! -f $IPMB_HOST_FLAG ]; then
+	touch $IPMB_HOST_FLAG
+	# Avoid the driver is loaded at same time by BMC and script
+	sleep 10
+	load_ipmb_host
+	check_ipmb_connection
+	# Avoid the driver is loaded at same time by BMC and script
+	sleep 10
+	rm -f $IPMB_HOST_FLAG
+fi

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -93,6 +93,7 @@ rm -f %{buildroot}/usr/lib64/OpenIPMI/*.la %{buildroot}/usr/lib64/OpenIPMI/*.a
 /usr/share/man/man8/ipmilan.8.gz
 %{_bindir}/ipmi*
 %{_bindir}/set_emu_param.sh
+%{_bindir}/load_ipmb_host.sh
 %{_bindir}/poll_set_emu_param.sh
 %{_bindir}/mlx_ipmid_init.sh
 %{_bindir}/mlx_emu_init.sh


### PR DESCRIPTION
1. Ensured proper flag handling to avoid conflicts between BMC and ARM during driver loading. Added IPMI_HOST_FLAG to prevent simultaneous loading of the IPMB host driver by the script or BMC.
2. If IPMB host is not loaded correctly, unload the drvier instead of keeping it.
3. Added delay before and after loading the driver to prevent simultaneous loading. Another script load_ipmb_host.sh is added to avoid set_emu_param.sh is affected by that delay.
4. Removed unnecessary whitespace and improved code formatting.

RM #3994990