### PR TITLE
Add quotation marks when getting nmcli output

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -431,7 +431,7 @@ get_connectx_net_info() {
 	if [ $? -eq 0 ]; then
 
 		# Check IPv4 connection type
-		file=$(nmcli -g ipv4.method con show $connection_name)
+		file=$(nmcli -g ipv4.method con show "$connection_name")
 
 		if [ "$file" = "auto" ]; then
 			echo "IPv4 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1
@@ -449,7 +449,7 @@ get_connectx_net_info() {
 	if [ $? -eq 0 ]; then
 
 		# Check IPv6 connection type
-		file=$(nmcli -g ipv6.method con show $connection_name)
+		file=$(nmcli -g ipv6.method con show "$connection_name")
 
 		if [ "$file" = "auto" ]; then
 			echo "IPv6 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1


### PR DESCRIPTION
In Debian, the output of $(nmcli -g GENERAL.CONNECTION dev show $eth) has space between the names, unlike Ubuntu's output. Because of this space char the nmcli command that uses that name gets only part of the name (debian only).

Debian example:
```
root@qa-hpe-ocp04-oob:~# connection_name=$(nmcli -g GENERAL.CONNECTION dev show $eth) 
root@qa-hpe-ocp04-oob:~# echo $connection_name
Ifupdown (oob_net0)
```

Ubuntu:
```
root@ldev-platform-11-121-bf:~# eth=oob_net0
root@ldev-platform-11-121-bf:~# connection_name=$(nmcli -g GENERAL.CONNECTION dev show $eth) 
root@ldev-platform-11-121-bf:~# echo $connection_name 
netplan-oob_net0
```

Tested:
```
root@qa-hpe-ocp04-oob:~# connection_name=$(nmcli -g GENERAL.CONNECTION dev show "$eth") 
root@qa-hpe-ocp04-oob:~# nmcli -g ipv4.method con show "$connection_name"
 auto
```

Fixes nvbug https://redmine.mellanox.com/issues/3995909