### PR TITLE
Move nmcli command to use ip commands for IP address origin

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -420,43 +420,34 @@ get_connectx_net_info() {
 	# Get gateway
 	ip r | grep default | grep "dev $eth" >> $EMU_PARAM_DIR/$file_name$1
 
-	# Get the connection name
-	connection_name=$(nmcli -g GENERAL.CONNECTION dev show $eth)
-
-	# Check if IPv4 address is assigned and is not a link local address
-	ifconfig $eth | grep "inet " | grep -v " 169.254."
+	# Determine IPv4 address origin
+	file=$(ip show addr dev $eth | grep "inet ")
 	if [ $? -eq 0 ]; then
-
-		# Check IPv4 connection type
-		file=$(nmcli -g ipv4.method con show "$connection_name")
-
-		if [ "$file" = "auto" ]; then
-			echo "IPv4 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1
-		elif [ "$file" = "manual" ]; then
-			echo "IPv4 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
-		else
+		if ["scope link" == $file ]; then
 			echo "IPv4 Address Origin: LinkLocal" >> $EMU_PARAM_DIR/$file_name$1
+		elif ["scope global dynamic" == $file ]; then
+			echo "IPv4 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1
+		else
+			echo "IPv4 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
 		fi
 	else
-		echo "IPv4 Address Origin: LinkLocal" >> $EMU_PARAM_DIR/$file_name$1
+		echo "IPv4 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
 	fi
 
-	# Check if IPv6 address is assigned and is not a link local address
-	ifconfig $eth | grep "inet6 " | grep -v " fe80::"
+	# Determine IPv6 address origin
+	file=$(ip show addr dev $eth | grep "inet6")
 	if [ $? -eq 0 ]; then
-
-		# Check IPv6 connection type
-		file=$(nmcli -g ipv6.method con show "$connection_name")
-
-		if [ "$file" = "auto" ]; then
-			echo "IPv6 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1
-		elif [ "$file" = "manual" ]; then
-			echo "IPv6 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
-		else
+		if ["scope link" == $file ]; then
 			echo "IPv6 Address Origin: LinkLocal" >> $EMU_PARAM_DIR/$file_name$1
+		elif ["autoconf" == $file ]; then
+			echo "IPv6 Address Origin: AutoConf" >> $EMU_PARAM_DIR/$file_name$1
+		elif ["scope global dynamic" == $file ]; then
+			echo "IPv6 Address Origin: DHCP" >> $EMU_PARAM_DIR/$file_name$1
+		else
+			echo "IPv6 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
 		fi
 	else
-		echo "IPv6 Address Origin: LinkLocal" >> $EMU_PARAM_DIR/$file_name$1
+		echo "IPv6 Address Origin: Static" >> $EMU_PARAM_DIR/$file_name$1
 	fi
 
 	data="prio|rx_symbol_err_phy|rx_pcs_symbol_err_phy|rx_crc_errors_phy"


### PR DESCRIPTION
eth0/eth1 interfaces are not managed in DPU's NetworkManager by default. We move to ip commands to determine the IP address origin. Current limitation is that it support a single IP address origin per IP type (IPv4/IPv6).

Tested:
Added IPv4 static address to enp3s0f0s0, oob_net0 has a DHCP IPv4 address. IPv6 in both is LinkLocal (oob_net0 has an extra one):

```
root@ldev-platform-11-121-bf:/run/emu_param# cat eth0
LAN Interface:
enp3s0f0s0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.1.100  netmask 255.255.255.0  broadcast 0.0.0.0
        inet6 fe80::50:bff:fea7:ff72  prefixlen 64  scopeid 0x20<link>
        ether 02:50:0b:a7:ff:72  txqueuelen 1000  (Ethernet)
        RX packets 239  bytes 77676 (77.6 KB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 132  bytes 38332 (38.3 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

enp3s0f0s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 02:50:0b:a7:ff:72 brd ff:ff:ff:ff:ff:ff
enp3s0f0s0:unmanaged
LinkStatus: UP
        Speed: 200000Mb/s
IPv4 Address Origin: Static
IPv6 Address Origin: LinkLocal
```

```
root@ldev-platform-11-121-bf:/run/emu_param# cat oob0
LAN Interface:
oob_net0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 10.237.40.135  netmask 255.255.0.0  broadcast 10.237.255.255
        inet6 fe80::a288:c2ff:fe0e:8736  prefixlen 64  scopeid 0x20<link>
        inet6 fdfd:fdfd:10:237:a288:c2ff:fe0e:8736  prefixlen 64  scopeid 0x0<global>
        ether a0:88:c2:0e:87:36  txqueuelen 1000  (Ethernet)
        RX packets 2583544  bytes 275942037 (275.9 MB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 6789  bytes 804685 (804.6 KB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

oob_net0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
    link/ether a0:88:c2:0e:87:36 brd ff:ff:ff:ff:ff:ff
    altname enamlnxbf17i0
        Speed: 1000Mb/s
default via 10.237.0.1 dev oob_net0 proto dhcp metric 101
IPv4 Address Origin: DHCP
IPv6 Address Origin: LinkLocal
```

