### PR TITLE
Increase transfer size to prevent FRU data loss

### DIFF
--- a/lanserv/mellanox-bf/mlx-bf-base.emu
+++ b/lanserv/mellanox-bf/mlx-bf-base.emu
@@ -136,5 +136,5 @@ mc_add_fru_data 0x30 16 3000 file 0 "/run/emu_param/eth_hw_counters"
 mc_add_fru_data 0x30 17 3200 file 0 "/run/emu_param/oob0"
 mc_add_fru_data 0x30 18 1280 file 0 "/run/emu_param/bf_fru"
 mc_add_fru_data 0x30 19 64 file 0 "/run/emu_param/product_name"
-mc_add_fru_data 0x30 20 700 file 0 "/run/emu_param/dmidecode_info"
+mc_add_fru_data 0x30 20 1310 file 0 "/run/emu_param/dmidecode_info"
 mc_enable 0x30

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -1011,5 +1011,5 @@ if  [ -n "$product_name" ]; then
 		echo "$key : $output" >> $EMU_PARAM_DIR/dmidecode_info
 	done
 
-	truncate -s 700 $EMU_PARAM_DIR/dmidecode_info
+	truncate -s 1310 $EMU_PARAM_DIR/dmidecode_info
 fi


### PR DESCRIPTION
The previous transfer size of 700 bytes was insufficient to transfer the dmidecode information when all fields contain 63 characters. This patch increases the transfer size to 1310 bytes to ensure all necessary dmidecode fields for FRU data are transferred correctly.

RM #4313828