### PR TITLE
Adjust BF device mst regex

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -5,6 +5,8 @@
 # journalctl -u set_emu_param
 
 EMU_PARAM_DIR=/run/emu_param
+# mt416*_pciconf0 is the pattern for BF devices
+BF_MST_DEVICE=/dev/mst/mt416*_pciconf0
 
 if [ ! -d $EMU_PARAM_DIR ]; then
 	mkdir $EMU_PARAM_DIR
@@ -568,7 +570,7 @@ fi
 if [ ! -d /dev/mst ]; then
 	mst start
 fi
-temp=$(mget_temp -d /dev/mst/mt*_pciconf0)
+temp=$(mget_temp -d $BF_MST_DEVICE)
 
 if [ -z "$temp" ]; then
 	remove_sensor "bluefield_temp"
@@ -795,7 +797,7 @@ get_fw_info() {
 	# Get VPD info
 	cat <<- EOF >> $EMU_PARAM_DIR/fw_info
 	vpd info:
-	$(mlxvpd -d /dev/mst/mt*_pciconf0)
+	$(mlxvpd -d $BF_MST_DEVICE)
 	EOF
 
 	if [ -d /sys/class/infiniband/mlx*_0 ]; then
@@ -890,7 +892,7 @@ if [ "$t" = "$fru_timer" ]; then
 	###################################
 	#        Get the fru info         #
 	###################################
-	flint -d /dev/mst/mt*_pciconf0 q full > $EMU_PARAM_DIR/bf_fru
+	flint -d $BF_MST_DEVICE q full > $EMU_PARAM_DIR/bf_fru
 	truncate -s 1280 $EMU_PARAM_DIR/bf_fru
 
 	###################################
@@ -978,7 +980,7 @@ if [ "$t" = "$fru_timer" ]; then
 	##########################################
 	#          Get BF UID info               #
 	##########################################
-	mlxreg -d /dev/mst/mt*_pciconf0 --reg_name MDIR --get | awk '{if(NR>2)print}' \
+	mlxreg -d $BF_MST_DEVICE --reg_name MDIR --get | awk '{if(NR>2)print}' \
 	       	| grep device | cut -d "x" -f 2 | tr -d '\n' > $EMU_PARAM_DIR/bf_uid
 	if [ ! -s $EMU_PARAM_DIR/bf_uid ]; then
 		cat <<- EOF > $EMU_PARAM_DIR/bf_uid


### PR DESCRIPTION
This commit adjusts the mst device path regex to be specific to BF devices. Fixes an issue where a CX is connected to a BF and both match the mt*_pciconf0. The mt416* is specific only for BF device, see more: https://confluence.nvidia.com/pages/viewpage.action?spaceKey=SW&title=Device+names

Tested:

```
root@ldev-platform-11-121-bf:~# cat /run/emu_param/bluefield_temp
49
root@ldev-platform-11-121-bf:~# cat /run/emu_param/bf_uid
23082d57b803da893d75969d719b89f29e344e41a1e10867be6a7f725b62b5d8root@ldev-platform-11-121-bf:~#
root@ldev-platform-11-121-bf:~# cat /run/emu_param/fw_info
BlueField ATF version: v2.2(release):4.11.0-39-gd32456976
BlueField UEFI version: 4.11.0-56-g2a025a1fd5
BlueField BSP version: 4.11.0.13602

OS Release Version: bf-bundle-3.0.0-97_25.04_debian-12_6.10_dev
BlueField OFED Version: MLNX_OFED_LINUX-25.04-0.5.0.0
vpd info:

  VPD-KEYWORD    DESCRIPTION             VALUE
  -----------    -----------             -----
Read Only Section:

  PN             Part Number             900-9D3B4-00EN-EAA
  EC             Revision                A9
  V2             N/A                     900-9D3B4-00EN-EAA
  SN             Serial Number           MT2329XZ010X
  V3             N/A                     14d2ae5ff034ee118000a088c20e8722
  VA             N/A                     MLX:MN=MLNX:CSKU=V2:UUID=V3:PCI=V0:MODL=D3B4
  V0             Misc Info               PCIeGen5 x16
  VU             N/A                     MT2329XZ010XECMLNXS0D0F0
  RV             Checksum Complement     0xae
  IDTAG          Board Id                BlueField-3 E-series DPU NDR/400GbE VPI single port QSFP112, PCIe Gen5.0 x16 FHHL, Crypto Enabled, 16GB on board DDR, BMC, Tall Bracket, IPN DK
connectx_fw_ver: 32.45.0386
board_id: MT_0000001033
node_guid: a088:c203:000e:872a
sys_image_guid: a088:c203:000e:8722
root@ldev-platform-11-121-bf:~# cat /run/emu_param/bf_fru
Image type:            FS4
FW Version:            32.45.0386
FW Release Date:       20.4.2025
Part Number:           900-9D3B4-00EN-E_DK_Ax
Description:           Nvidia BlueField-3 BF3140L E-series SuperNic NDR/400GbE single port QSFP112; PCIe Gen5.0 x16 FHHL; Crypto Enabled; 16GB on board DDR; integrated BMC; Tall Bracket; IPN DK
Product Version:       32.45.0386
Rom Info:              type=UEFI Virtio net version=21.4.13 cpu=AMD64,AARCH64
                       type=UEFI Virtio blk version=22.4.14 cpu=AMD64,AARCH64
                       type=UEFI version=14.38.14 cpu=AMD64,AARCH64
                       type=PXE version=3.7.500 cpu=AMD64
Description:           UID                GuidsNumber
Base GUID:             a088c203000e8722        22
Base MAC:              a088c20e8722            22
Image VSD:             N/A
Device VSD:            N/A
PSID:                  MT_0000001033
Security Attributes:   secure-fw, dev
Default Update Method: fw_ctrl
Life cycle:            GA SECURED
Secure Boot Capable:   Enabled
EFUSE Security Ver:    0
Image Security Ver:    0
Security Ver Program:  Manually ; Disabled
Encryption:            Enabled
root@ldev-platform-11-121-bf:~#
```