### PR TITLE
Fix IPMB host crash

### DIFF
--- a/lanserv/mellanox-bf/mellanox_bf_mod.c
+++ b/lanserv/mellanox-bf/mellanox_bf_mod.c
@@ -15,10 +15,6 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
-#include <linux/module.h>
-#include <fcntl.h>
-#include <ctype.h>
 
 #include <OpenIPMI/ipmi_msgbits.h>
 #include <OpenIPMI/ipmi_bits.h>
@@ -29,115 +25,10 @@
 #define PVERSION             "1.0.2"
 #define NVIDIA_IANA          5703
 #define GET_SYSTEM_TIME_CMD  1
-#define LOAD_IPMB_DRIVER_CMD 2
-
-#define IPMB_HOST_PATH           "modinfo ipmb_host --field filename"
-#define FLAG_PATH                "/run/emu_param/ipmb_host_driver_loaded"
-#define IPMB_HOST_PARAM          "slave_add=0x10"
-#define REGISTER_I2C_NEW_DEVICE  "echo ipmb-host 0x1011 > /sys/bus/i2c/devices/i2c-1/new_device"
-#define I2C_NEW_DEVICE           "/sys/bus/i2c/devices/i2c-1/1-1011/"
-
-#define init_module(module_image, len, param_values) syscall(__NR_init_module, module_image, len, param_values)
-#define delete_module(name, flags) syscall(__NR_delete_module, name, flags)
 
 /**************************************************************************
  * Nvidia - Mellanox OEM commands.
  *************************************************************************/
-
-/**
- * Checks in /proc/modules whether a kernel module is loaded
- *
- * @param driver The name of the driver
- * @return 1 if the module is loaded, 0 otherwise
- */
-static int module_is_loaded(char *driver)
-{
-    /* use the same buffer length as lsmod */
-    char buffer[4096];
-    FILE * fmod = fopen("/proc/modules", "r");
-    int ret = 0;
-
-    int mod_len = strlen(driver);
-    if (mod_len > 4095) {
-        return 0;
-    }
-
-    if (!fmod) {
-        return 0;
-    }
-
-    while (fgets(buffer, sizeof(buffer), fmod)) {
-        if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
-            /* module is found */
-            ret = 1;
-            break;
-        }
-    }
-
-    fclose(fmod);
-    return ret;
-}
-
-/**
- * Load the ipmb_host driver
- *
- * @return 1 if the ipmb_host is loaded successful, 0 otherwise
- */
-static int load_ipmb_host_driver()
-{
-    int ret = 0;
-    int driver_fd, path_len;
-    size_t module_size;
-    struct stat st;
-    void *module;
-    char path_buffer[256];
-    FILE * fp;
-
-    /* ipmb_host is already loaded before the BMC booted up, need unload it first */
-    if (module_is_loaded("ipmb_host") == 1) {
-        if (delete_module("ipmb_host", O_NONBLOCK) != 0) {
-            return ret;
-        }
-    }
-
-    /* Read the path of ipmb_host driver file*/
-    fp = popen(IPMB_HOST_PATH, "r");
-    if (!fp) {
-        return ret;
-    }
-    fgets(path_buffer, sizeof(path_buffer), fp);
-    pclose(fp);
-    path_len = strlen(path_buffer);
-    path_buffer[path_len-1] = '\0';
-
-    /* Start loading the driver */
-    driver_fd = open(path_buffer, O_RDONLY);
-    if (driver_fd < 0) {
-        return ret;
-    }
-    fstat(driver_fd, &st);
-    module_size = st.st_size;
-    module = malloc(module_size);
-    if(!module) {
-        return ret;
-    }
-    read(driver_fd, module, module_size);
-    close(driver_fd);
-    if (init_module(module, module_size, IPMB_HOST_PARAM) != 0) {
-        free(module);
-        return ret;
-    }
-    free(module);
-
-    /* Register the new I2C device if not exist*/
-    if (access(I2C_NEW_DEVICE, F_OK) != 0) {
-        if (system(REGISTER_I2C_NEW_DEVICE) == -1) {
-            return ret;
-        }
-    }
-    ret = 1;
-    return ret;
-}
 
 /*
 * Handler for getting the DPU system time (real time - UTC)
@@ -159,34 +50,6 @@ static void handle_oem_command(lmc_data_t    *mc,
         mc->emu->sysinfo->get_real_time(mc->emu->sysinfo, &t);
         ipmi_set_uint32(rdata+1, t.tv_sec);
         *rdata_len = 5;
-    }
-    break;
-
-    case LOAD_IPMB_DRIVER_CMD:
-    {
-        rdata[0] = 0x0;
-        *rdata_len = 2;
-
-        /* If flag exists, driver don't need to be reloaded again */
-        if (access(FLAG_PATH, F_OK) == 0) {
-            rdata[1] = 0x2;
-            return;
-        }
-
-        /* Create a flag to indicate that the handler tried to load ipmb_host driver */
-        flag_fd = open(FLAG_PATH, O_RDWR | O_CREAT, S_IRUSR | S_IRGRP | S_IROTH);
-        if (flag_fd < 0) {
-            rdata[1] = 0x0;
-            return;
-        }
-
-        /* Load the ipmb_host driver */
-        /* Return 1 if the driver is loaded successful, 0 otherwise */
-        if (load_ipmb_host_driver() == 1) {
-            rdata[1] = 0x1;
-        } else {
-            rdata[1] = 0x0;
-        }
     }
     break;
 

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -83,6 +83,8 @@ fi
 
 I2C_NEW_DEV=/sys/bus/i2c/devices/i2c-$i2cbus/new_device
 I2C_DEL_DEV=/sys/bus/i2c/devices/i2c-$i2cbus/delete_device
+# After IPMB host detect the BMC, it will create BMC device created under sysfs i2c bus.
+SYS_BUS_BMC_DEVICES="/sys/bus/i2c/devices/*/bmc"
 # The IPMB_HOST_FLAG is created if the ipmb-host driver is loaded by the BMC
 # using ipmi oem command: ipmitool -I ipmb raw 0x2e 0x2 0x47 0x16 0x0
 # This flag is cleared after reboot the DPU.
@@ -92,33 +94,35 @@ IPMB_HOST_FLAG=/run/emu_param/ipmb_host_driver_loaded
 IPMB_RETRY_FLAG=/run/emu_param/ipmb_host_driver_retry
 
 load_ipmb_host() {
-	# There is a corner case that the ipmb-host driver can be loaded by this
-	# script and BMC at the same time. The handshake could be interrupted
-	# and cause the driver panic.
-	# If IPMB_HOST_FLAG exists on the system, that means the ipmb-host driver
-	# is loaded by BMC and the BMC is ready to do the handshake with DPU, there
-	# is no need to load it again. The script should check this flag before
-	# loading the ipmb-host to avoid the ipmi-host is loading or loaded by the
-	# BMC.
-	if [ ! -f $IPMB_HOST_FLAG ]; then
-		# The script should create this flag to avoid the BMC try to load the
-		# driver when the script is loading it.
-		touch $IPMB_HOST_FLAG
-		modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
-		echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
-		# The script should remove this flag to avoid the BMC can't reload the
-		# driver after BMC boot up.
-		rm $IPMB_HOST_FLAG
-	fi
+	modprobe ipmb_host slave_add=$IPMB_HOST_CLIENTADDR
 }
 
 remove_ipmb_host() {
-	if [ ! -f $IPMB_HOST_FLAG ]; then
-		touch $IPMB_HOST_FLAG
-		echo $IPMB_HOST_ADD > $I2C_DEL_DEV
-		rmmod ipmb_host
-		rm $IPMB_HOST_FLAG
+	rmmod ipmb_host
+}
+
+check_ipmb_connection() {
+	# Check the IPMB host driver is successful to connect to the BMC
+	if ls $SYS_BUS_BMC_DEVICES 1> /dev/null 2>&1; then
+		rm -f $IPMB_RETRY_FLAG
+	else
+		# If IPMB retry flag file exists, read and increment the retry count
+		if [ -f $IPMB_RETRY_FLAG ]; then
+			retries=$(cat $IPMB_RETRY_FLAG)
+			retries=$((retries + 1))
+		else
+			retries=1
+		fi
+		# Update the retry count in the file
+		echo $retries > $IPMB_RETRY_FLAG
+		remove_ipmb_host
 	fi
+}
+
+# Function to load IPMB host with retry mechanism
+load_ipmb_host_with_retry() {
+	load_ipmb_host
+	check_ipmb_connection
 }
 
 if [ "$i2cbus" != "NONE" ]; then
@@ -139,49 +143,36 @@ if [ "$i2cbus" != "NONE" ]; then
 	
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
-	
-    if find /lib/modules/ /usr/lib/modules/ \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
+
+	if find /lib/modules/ /usr/lib/modules/ \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
 		is_ipmb_host_driver=true
-    fi
-	# The BMC is slower than DPU to be ready on BF2 and BF1.
-	# The BMC is faster than DPU to be ready on BF3.
-	# Currently we want to keep the delay for BF2 and BF1.
-	# As the bf_family name of Roy and Roy-B are the same for BF2 and BF3,
-	# We need to check it is Roy or Roy-B according to the platform ID.
-	# The bf_version is used to distinguish the "Roy" and "Roy-B".
-	# Roy-B doesn't need the delay of loading the driver.
-    if [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then
+	fi
+	# The i2c bus between BMC and DPU could be overused and susceptible to be busy.
+	if [ -f $IPMB_RETRY_FLAG ]; then
+		load_ipmb_host_with_retry
+	# Load the IPMB Host driver during the initial boot of the BlueField device
+	# During the initial boot, if the ipmb_host driver is not loaded, we won't have the retry flag and host flag
+	elif [ ! "$(lsmod | grep ipmb_host)" ] && $is_ipmb_host_driver; then
+		# The BMC is slower than DPU to be ready on BF2 and BF1.
+		# The BMC is faster than DPU to be ready on BF3.
+		# Currently we want to keep the delay for BF2 and BF1.
+		# As the bf_family name of Roy and Roy-B are the same for BF2 and BF3,
+		# We need to check it is Roy or Roy-B according to the platform ID.
+		# The bf_version is used to distinguish the "Roy" and "Roy-B".
+		# Roy-B doesn't need the delay of loading the driver.
 		if [ "$bffamily" = "BlueSphere" ] || [ "$bffamily" = "PRIS" ] ||
-		   [ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
-		   [ "$bffamily" = "Dell-Camelantis" ] || [ "$bffamily" = "El-Dorado" ] ||
-		   ([ "$bffamily" = "Roy" ] && [ "$bf_version" = $BF2_PLATFORM_ID ]); then
+			[ "$bffamily" = "Camelantis" ] || [ "$bffamily" = "Aztlan" ] ||
+			[ "$bffamily" = "Dell-Camelantis" ] ||
+			([ "$bffamily" = "Roy" ] && [ "$bf_version" = $BF2_PLATFORM_ID ]); then
 			# Load the driver 2.5mn after boot to give the BMC time
 			# to get ready for IPMB transactions.
 			if [ "$curr_time" -ge 150 ]; then
-				load_ipmb_host
-				ipmitool mc info > /dev/null 2>&1
-				if [ ! $? -eq 0 ]; then
-					touch $IPMB_RETRY_FLAG
-				fi
+				echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+				load_ipmb_host_with_retry
 			fi
 		else
-			load_ipmb_host
-			ipmitool mc info > /dev/null 2>&1
-			if [ ! $? -eq 0 ]; then
-				touch $IPMB_RETRY_FLAG
-			fi
-		fi
-	fi
-	# The i2c bus between BMC and DPU could be overused and susceptible to be busy.
-	# Retry every 6mn after boot if the driver fails to load.
-	if [ -f $IPMB_RETRY_FLAG ]; then
-		if [ $(( $t % 6 )) -eq 0 ] && [ "$curr_time" -ge 300 ]; then
-			remove_ipmb_host
-			load_ipmb_host
-			ipmitool mc info > /dev/null 2>&1
-			if [ $? -eq 0 ]; then
-				rm $IPMB_RETRY_FLAG
-			fi
+			echo ipmb-host $IPMB_HOST_ADD > $I2C_NEW_DEV
+			load_ipmb_host_with_retry
 		fi
 	fi
 fi #support_ipmb


### PR DESCRIPTION
This commit revert the handler for loading ipmb driver, this is because the driver loading and retry checking happened at the same time could cause the driver to crash because the ipmb response mismatch to the ipmb_host driver.

It also addresses the crash issue by modifying the method to verify the IPMB host driver's connection to the BMC. The previous implementation used ipmitool mc info to check the connection, which could cause the IPMB host driver crash and has been replaced with a directory existence check for the BMC device under sysfs.