### PR TITLE
Ensure mlx_ipmid reloads when IPMB support becomes available

### DIFF
--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -5,7 +5,7 @@ Before=set_emu_param.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD} ${BF_VERSION}'
+ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD} ${BF_VERSION} mlx_ipmid'
 ExecStartPre=/bin/bash -c '/usr/bin/mlx_emu_init.sh ${FRU_TYPE}' 
 ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always

--- a/lanserv/mellanox-bf/mlx_ipmid_init.sh
+++ b/lanserv/mellanox-bf/mlx_ipmid_init.sh
@@ -21,4 +21,4 @@
 # $5 time interval for executing set_emu_param.sh in seconds.
 
 rm -f /run/log/mlx_ipmid.log
-/usr/bin/set_emu_param.sh $1 $2 $3 $4 $5 $6
+/usr/bin/set_emu_param.sh $1 $2 $3 $4 $5 $6 $7

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -5,7 +5,7 @@ After=mlx_ipmid.service
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
 ExecStartPre=/bin/bash -c 'rm -f /run/log/set_emu_param.log'
-ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${BF_VERSION}'
+ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${BF_VERSION} set_emu_param'
 StandardOutput=file:/run/log/set_emu_param.log
 StandardError=file:/run/log/set_emu_param.log
 SyslogIdentifier=setipmi


### PR DESCRIPTION
After installing the new BFB image, if the bffamily script failed to retrieve the correct platform name, resulting in "Unknown Product Family" being passed to the mlx_ipmid service. The mlx_ipmid service started before the IPMB drivers were loaded, although the drivers could begin loading after the set_emu_param service started. As a result, mlx_ipmid did not detect that it needed to load the IPMB drivers. Later, when set_emu_param started, it successfully retrieved the correct platform name, loaded all necessary drivers, and updated the configuration file. However, since ipmi_sim had already started earlier with an incomplete configuration, it did not recognize the IPMB channel.

This patch refactors set_emu_param.sh to accept a source_service parameter and introduces a flag mechanism to track IPMB support. If mlx_ipmid starts without IPMB support, a flag is created. When set_emu_param later detects that IPMB support is required, it removes the flag and restarts mlx_ipmid, ensuring the correct configuration is loaded.

RM #4463052