### PR TITLE
Modifying set_emu_param.sh to handle compressed kernel modules

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -182,7 +182,7 @@ if [ "$i2cbus_slave" != "NONE" ]; then
 	# load the ipmb_host driver, if installed in BF
 	is_ipmb_host_driver=false
 
-	if find /lib/modules/ /usr/lib/modules/ \( -name "ipmb_host.ko" -o -name "ipmb-host.ko" \) -print -quit | grep -q .; then
+	if modinfo ipmb_host > /dev/null 2>&1; then
 		is_ipmb_host_driver=true
 	fi
 	# The i2c bus between BMC and DPU could be overused and susceptible to be busy.


### PR DESCRIPTION
In-tree kernel modules coming with the Ubuntu 24.04 kernel are zst compressed, which needs to be handled in set_emu_param.sh script.

Test:

Before change, executing `ipmitool mc info` returns:
```
Could not open device at /dev/ipmi0 or /dev/ipmi/0 or /dev/ipmidev/0: No such file or directory
```
After change, the same command is successful:
```
Device ID                 : 1
Device Revision           : 1
Firmware Revision         : 24.10
IPMI Version              : 2.0
Manufacturer ID           : 33049
Manufacturer Name         : Mellanox Technologies LTD
Product ID                : 4 (0x0004)
Product Name              : Unknown (0x04)
Device Available          : yes
Provides Device SDRs      : yes
Additional Device Support :
    Sensor Device
    SDR Repository Device
    SEL Device
    FRU Inventory Device
    IPMB Event Receiver
    Chassis Device
Aux Firmware Rev Info     :
    0x10
    0x21
    0x00
    0x00
```

Fixes jira https://redmine.mellanox.com/issues/4542954