### PR TITLE
Validating set_emu_param.sh input arguments

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -19,6 +19,34 @@ if [ ! -s  $EMU_PARAM_DIR/ip_addresses ]; then
 	truncate -s 61 $EMU_PARAM_DIR/ip_addresses
 fi
 
+# Validate that all required arguments are provided
+if [ $# -ne 7 ]; then
+    echo "Error: This script requires exactly 7 arguments."
+    echo "Usage: $0 <bffamily> <support_ipmb> <oob_ip> <external_ddr> <loop_period> <bf_version> <source_service>"
+    echo ""
+    echo "Arguments:"
+    echo "  bffamily       - BlueField family (e.g., Bluewhale, BlueSphere, PRIS, Camelantis, Aztlan, Dell-Camelantis, Roy, Moonraker, Goldeneye)"
+    echo "  support_ipmb   - IPMB support flag (NONE or numeric value for i2c bus)"
+    echo "  oob_ip         - Out-of-band IP address (0 for disabled)"
+    echo "  external_ddr   - External DDR flag (YES or NO)"
+    echo "  loop_period    - Loop period in seconds (positive integer)"
+    echo "  bf_version     - BlueField version (hexadecimal value)"
+    echo "  source_service - Source service name (e.g., set_emu_param, mlx_ipmid)"
+    echo ""
+    echo "Example: $0 BlueSphere 1 192.168.1.100 NO 30 0x00000214 set_emu_param"
+    exit 1
+fi
+
+# Check that all arguments are not empty
+for i in 1 2 3 4 5 6 7; do
+    eval "arg=\$$i"
+    if [ -z "$arg" ]; then
+        echo "Error: Argument $i is empty"
+        echo "Usage: $0 <bffamily> <support_ipmb> <oob_ip> <external_ddr> <loop_period> <bf_version> <source_service>"
+        exit 1
+    fi
+done
+
 bffamily=$1
 support_ipmb=$2
 oob_ip=$3


### PR DESCRIPTION
Validating that the expected number of arguments was given and that each argument is non-empty.

Test:
Before the change, calling the script with no arguments would cause several errors:
```
~# set_emu_param.sh
/usr/bin/set_emu_param.sh: line 41: 3600 / : syntax error: operand expected (error token is "/ ") /usr/bin/set_emu_param.sh: line 56: (  - 0x010) *  : syntax error: operand expected (error token is "*  ") /usr/bin/set_emu_param.sh: line 141: /sys/bus/i2c/devices/i2c-/new_device: No such file or directory mlxbf_ptm module not loaded, loading now.
modprobe: FATAL: Module mlxbf_ptm not found in directory /lib/modules/6.8.0-1006-bluefield-64k /usr/bin/set_emu_param.sh: line 892: % 10 : syntax error: operand expected (error token is "% 10 ") /usr/bin/set_emu_param.sh: line 911: % 60 : syntax error: operand expected (error token is "% 60 ")
```
After the change, the script returns with code 1 and outputs an explanation about the correct usage:
```
~# set_emu_param.sh
Error: This script requires exactly 7 arguments.
Usage: /usr/bin/set_emu_param.sh <bffamily> <support_ipmb> <oob_ip> <external_ddr> <loop_period> <bf_version> <source_service>

Arguments:
  bffamily       - BlueField family (e.g., Bluewhale, BlueSphere, PRIS, Camelantis, Aztlan, Dell-Camelantis, Roy, Moonraker, Goldeneye)
  support_ipmb   - IPMB support flag (NONE or numeric value for i2c bus)
  oob_ip         - Out-of-band IP address (0 for disabled)
  external_ddr   - External DDR flag (YES or NO)
  loop_period    - Loop period in seconds (positive integer)
  bf_version     - BlueField version (hexadecimal value)
  source_service - Source service name (e.g., set_emu_param, mlx_ipmid)

Example: /usr/bin/set_emu_param.sh BlueSphere 1 192.168.1.100 NO 30 0x00000214 set_emu_param
```

Fixes jira https://redmine.mellanox.com/issues/4544851