### PR TITLE
Handle error in mlxlink reading temp

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -240,7 +240,7 @@ get_qsfp_eeprom_data() {
 # $2 is the output file name
 get_qsfp_temp() {
 	temp=$(mlxlink -d $1 -m 2> /dev/null | grep Temperature | cut -f 2 -d ":" | tr -d " ")
-	if [ "$temp" != "N/A" ]; then
+	if [ "$temp" != "N/A" ] && [ "$temp" != "0[0..0]" ]; then
 		temp=$(echo "$temp" | awk -F'[^0-9]+' '{print $1}')
 		echo $temp > $EMU_PARAM_DIR/$2
 	else


### PR DESCRIPTION
mlxlink can have a temp read failure that will show "0 [0..0]" for Temprature, so adding a way to handle.

Tested:
```
Puting the bad string into a file and updating set_emu_param to read
from the file instead of mlxlink, verifying bad string is handled and
good temps still work.
```