### PR TITLE
Handle configuration lines starting with null bytes

### DIFF
--- a/lanserv/config.c
+++ b/lanserv/config.c
@@ -755,9 +755,22 @@ read_config(sys_data_t *sys,
     while (fgets(buf, sizeof(buf), f) != NULL) {
 	line++;
 
-	tok = mystrtok(buf, " \t\n", &tokptr);
-	if (!tok || (tok[0] == '#'))
+	// Skip null bytes at the beginning of the line
+	char *line_start = buf;
+	char *buf_end = buf + sizeof(buf) - 1;
+	while (*line_start == '\0' && line_start < buf_end) {
+	    line_start++;
+	}
+
+	// If we've reached the end of the line after skipping nulls, skip this line
+	if (*line_start == '\n' || *line_start == '\r' || *line_start == '\0') {
 	    continue;
+	}
+
+	tok = mystrtok(line_start, " \t\n", &tokptr);
+	if (!tok || (tok[0] == '#')) {
+	    continue;
+	}
 
 	if (strcmp(tok, "define") == 0) {
 	    const char *varname;


### PR DESCRIPTION
There is an unexpected newline containing many null bytes (ASCII 0x00) in the IPMB configuration section of the customer’s mlx-bf.lan.conf file, which prevents mlx-OpenIPMI to parse the IPMB channel settings.

This unexpected newline is caused by the system power cycles during the execution of adding ipmb configuration in file. Incomplete writes during power loss can leave files in an inconsistent state with null bytes padding to the expected file size.

When configuration files contain lines that begin with null bytes (ASCII 0x00) but have valid configuration data after those null bytes, the current parser will skip the entire line.

This commit modifies the configuration parser to:
- Skip any leading null bytes at the start of each line
- Parse the remaining content if valid configuration data is found
- Only skip lines that are truly empty after removing null bytes

RM #4608154