### PR TITLE
Remove rasdaemon dependency in deb and rpm.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,6 @@ Source: mlx-openipmi
 Section: admin
 Priority: optional
 Maintainer: Noël Köthe <noel@debian.org>
-Depends: rasdaemon
 Build-Depends: debhelper (>> 11.0.0), libsnmp-dev, libpopt-dev, libncurses5-dev, chrpath, libssl-dev
 Standards-Version: 4.1.4
 Homepage: http://openipmi.sourceforge.net/

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -42,7 +42,6 @@ BuildRoot: %{?build_root:%{build_root}}%{!?build_root:/var/tmp/OFED}
 Vendor: Mellanox Technologies
 BuildRequires: popt-devel
 BuildRequires: ncurses-devel
-Requires: rasdaemon
 Provides: OpenIPMI
 Provides: OpenIPMI-libs
 Provides: OpenIPMI-modalias


### PR DESCRIPTION
There is a conflict is happening due to perf package bundling libtraceevent library in the same package, while a newer rasdaemon is requesting a separate libtraceevent package as a new dependency
this is an upstream issue with anolis

because we're explicitly installing perf for performance analysis, and also install mlx-openipmi, which requires rasdaemon, and the newest rasdaemon 0.8 requires separate libtraceevents package, while at the same time perf is bundling the libtraceevents library in the same path, rpm will see this and throw a conflict

After testing on deb, it see, that the rasdaemon dependency can be removed from deb and rpm.