### PR TITLE
set_emu_param: add debug print at startup

### DIFF
--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -55,6 +55,8 @@ loop_period=$5
 bf_version=$6
 source_service=$7
 
+echo "set_emu_param debug: $(date -Is) pid=$$ bffamily=${bffamily} source_service=${source_service}" >&2
+
 # This timer is used to update the FRUs
 # once every hour. It also informs the user
 # how much time is left before the next FRU


### PR DESCRIPTION
Emit one line to stderr with timestamp, pid, bffamily, and source_service so journalctl -u set_emu_param shows invocations during investigation.


Made-with: Cursor