### PR TITLE
Fix mlx-openipmi logging for RHCOS compatibility

### DIFF
--- a/debian/mlx-openipmi.files
+++ b/debian/mlx-openipmi.files
@@ -8,7 +8,3 @@ usr/share/man/man5/*.5
 usr/share/man/man7/ipmi_cmdlang.7
 usr/share/man/man7/openipmi_conparms.7
 usr/share/man/man8/ipmilan.8
-/etc/logrotate.d/mlx_ipmid
-/etc/logrotate.d/set_emu_param
-/etc/rsyslog.d/mlx_ipmid.conf
-/etc/rsyslog.d/set_emu_param.conf

--- a/lanserv/mellanox-bf/Makefile.am
+++ b/lanserv/mellanox-bf/Makefile.am
@@ -31,14 +31,7 @@ install-data-local:
 	$(INSTALL) -m 644 $(srcdir)/fru_type/config_type_0.sh "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/fru_type/config_type_1.sh  "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf";
+	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/";
 
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
@@ -54,11 +47,6 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf3.emu"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/progconf"
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
-	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"
-	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
-	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
-	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
-	-rmdir "$(DESTDIR)/run/log/" 2>/dev/null
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null
 	-rmdir "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox" 2>/dev/null
 	-rmdir "$(DESTDIR)/lib/systemd/system" 2>/dev/null

--- a/lanserv/mellanox-bf/Makefile.in
+++ b/lanserv/mellanox-bf/Makefile.in
@@ -745,14 +745,7 @@ install-data-local:
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf2.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 644 $(srcdir)/mlx-bf3.emu "$(DESTDIR)$(sysconfdir)/ipmi/"; \
 	$(INSTALL) -m 755 $(srcdir)/progconf "$(DESTDIR)$(sysconfdir)/ipmi/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)/run/log/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/logrotate.d/"; \
-	$(INSTALL) -m 755 -d "$(DESTDIR)$(sysconfdir)/rsyslog.d/"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"; \
-	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"; \
-	$(INSTALL) -m 644 $(srcdir)/set_emu_param.conf "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf";
+	$(INSTALL) -m 644 $(srcdir)/mlx_ipmid.service "$(DESTDIR)/lib/systemd/system/";
 
 uninstall-local:
 	-rm -f "$(DESTDIR)/lib/systemd/system/set_emu_param.service"
@@ -768,11 +761,6 @@ uninstall-local:
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/mlx-bf3.emu"
 	-rm -f "$(DESTDIR)$(sysconfdir)/ipmi/progconf"
 	-rm -f "$(DESTDIR)/lib/systemd/system/mlx_ipmid.service"
-	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/mlx_ipmid"
-	-rm -f "$(DESTDIR)$(sysconfdir)/logrotate.d/set_emu_param"
-	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/mlx_ipmid.conf"
-	-rm -f "$(DESTDIR)$(sysconfdir)/rsyslog.d/set_emu_param.conf"
-	-rmdir "$(DESTDIR)/run/log/" 2>/dev/null
 	-rmdir "$(DESTDIR)$(sysconfdir)/ipmi" 2>/dev/null
 	-rmdir "$(DESTDIR)$(localstatedir)/ipmi_sim/mellanox" 2>/dev/null
 	-rmdir "$(DESTDIR)/lib/systemd/system" 2>/dev/null

--- a/lanserv/mellanox-bf/mlx_ipmid
+++ b/lanserv/mellanox-bf/mlx_ipmid
@@ -1,8 +1,0 @@
-/run/log/mlx_ipmid.log {
-        size 100k
-        rotate 4
-        missingok
-        nodateext
-        compress
-        copytruncate
-}

--- a/lanserv/mellanox-bf/mlx_ipmid.conf
+++ b/lanserv/mellanox-bf/mlx_ipmid.conf
@@ -1,2 +1,0 @@
-if $programname == 'ipmi_sim' then /run/log/mlx_ipmid.log
-&stop

--- a/lanserv/mellanox-bf/mlx_ipmid.service
+++ b/lanserv/mellanox-bf/mlx_ipmid.service
@@ -7,12 +7,13 @@ Before=set_emu_param.service
 EnvironmentFile=/etc/ipmi/progconf
 ExecStartPre=/bin/bash -c '/usr/bin/mlx_ipmid_init.sh ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${LOOP_PERIOD} ${BF_VERSION} mlx_ipmid'
 ExecStartPre=/bin/bash -c '/usr/bin/mlx_emu_init.sh ${FRU_TYPE}' 
-ExecStart=/usr/bin/ipmi_sim -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
+ExecStart=/usr/bin/ipmi_sim -n -c /etc/ipmi/mlx-bf.lan.conf -f /etc/ipmi/mlx-bf.emu -s /var
 Restart=always
 RestartSec=10
 TimeoutSec=60
-StandardOutput=append:/run/log/mlx_ipmid.log
-StandardError=append:/run/log/mlx_ipmid.log
+StandardOutput=journal
+StandardError=journal
+SyslogLevel=debug
 
 [Install]
 WantedBy=multi-user.target

--- a/lanserv/mellanox-bf/mlx_ipmid_init.sh
+++ b/lanserv/mellanox-bf/mlx_ipmid_init.sh
@@ -1,15 +1,8 @@
 #! /bin/sh
 
 # This wrapper file is passed as ExecStartPre in
-# mlx_ipmid.service because the syntax:
-# StandardOutput=append:...
-# is only supported in systemd version >= 240.
-# Some linux distros (CentOS8.2 for example), support
-# older versions of systemd.
-# So use StandardOutput=file:...
-# The downside of this is that the whole log files
-# contents are overwritten each time the service is
-# restarted. The file needs to be deleted every time.
+# mlx_ipmid.service to initialize emulator data before
+# starting ipmi_sim. Service logs are sent to journald.
 
 # Arguments passed to this script:
 # $1 is set to "Bluewhale" if it is a BlueWhale board.
@@ -20,5 +13,4 @@
 # $4 should be set to 1 if external ddrs are supported.
 # $5 time interval for executing set_emu_param.sh in seconds.
 
-rm -f /run/log/mlx_ipmid.log
 /usr/bin/set_emu_param.sh $1 $2 $3 $4 $5 $6 $7

--- a/lanserv/mellanox-bf/set_emu_param
+++ b/lanserv/mellanox-bf/set_emu_param
@@ -1,8 +1,0 @@
-/run/log/set_emu_param.log {
-        size 100k
-        rotate 4
-        missingok
-        nodateext
-        compress
-        copytruncate
-}

--- a/lanserv/mellanox-bf/set_emu_param.conf
+++ b/lanserv/mellanox-bf/set_emu_param.conf
@@ -1,2 +1,0 @@
-if $programname == 'setipmi' then /run/log/set_emu_param.log
-& stop

--- a/lanserv/mellanox-bf/set_emu_param.service
+++ b/lanserv/mellanox-bf/set_emu_param.service
@@ -4,10 +4,10 @@ After=mlx_ipmid.service
 
 [Service]
 EnvironmentFile=/etc/ipmi/progconf
-ExecStartPre=/bin/bash -c 'rm -f /run/log/set_emu_param.log'
 ExecStart=/bin/bash -c '/usr/bin/poll_set_emu_param.sh ${LOOP_PERIOD} ${BF_FAMILY} ${SUPPORT_IPMB} ${OOB_IP} ${EXTERNAL_DDR} ${BF_VERSION} set_emu_param'
-StandardOutput=file:/run/log/set_emu_param.log
-StandardError=file:/run/log/set_emu_param.log
+StandardOutput=journal
+StandardError=journal
+SyslogLevel=debug
 SyslogIdentifier=setipmi
 
 [Install]

--- a/lanserv/mellanox-bf/set_emu_param.sh
+++ b/lanserv/mellanox-bf/set_emu_param.sh
@@ -293,7 +293,7 @@ get_qsfp_eeprom_data() {
 	| tr -d "\n"  | perl -lpe '$_=pack"H*",$_' >  $EMU_PARAM_DIR/tmp
 
 	# Make sure binary data packed is 256 bytes
-	dd if=$EMU_PARAM_DIR/tmp of=$EMU_PARAM_DIR/$2 bs=1 skip=0 count=256
+	dd if=$EMU_PARAM_DIR/tmp of=$EMU_PARAM_DIR/$2 bs=1 skip=0 count=256 2>/dev/null
 
 	rm $EMU_PARAM_DIR/tmp
 }
@@ -495,8 +495,7 @@ get_connectx_net_info() {
 	connection_name=$(nmcli -g GENERAL.CONNECTION dev show $eth)
 
 	# Check if IPv4 address is assigned and is not a link local address
-	ifconfig $eth | grep "inet " | grep -v " 169.254."
-	if [ $? -eq 0 ]; then
+	if ifconfig $eth | grep "inet " | grep -v " 169.254." > /dev/null; then
 
 		# Check IPv4 connection type
 		file=$(nmcli -g ipv4.method con show "$connection_name")
@@ -513,8 +512,7 @@ get_connectx_net_info() {
 	fi
 
 	# Check if IPv6 address is assigned and is not a link local address
-	ifconfig $eth | grep "inet6 " | grep -v " fe80::"
-	if [ $? -eq 0 ]; then
+	if ifconfig $eth | grep "inet6 " | grep -v " fe80::" > /dev/null; then
 
 		# Check IPv6 connection type
 		file=$(nmcli -g ipv6.method con show "$connection_name")
@@ -1026,7 +1024,7 @@ if [ "$t" = "$fru_timer" ]; then
 		CID=`printf '00 %.0s' $(seq 1 16)`
 	fi
 	echo $CID |tr -d ' ' | tr -d '\n' | perl -lpe '$_=pack"H*",$_' > $EMU_PARAM_DIR/temp
-	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_cid bs=1 skip=0 count=16
+	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_cid bs=1 skip=0 count=16 2>/dev/null
 
 	# CSD binary data
 	CSD=`find /sys/devices -name 'csd'| grep mmc| xargs cat| sed 's/.\{2\}/& /g'`
@@ -1034,7 +1032,7 @@ if [ "$t" = "$fru_timer" ]; then
 		CSD=`printf '00 %.0s' $(seq 1 16)`
 	fi
 	echo $CSD |tr -d ' ' | tr -d '\n' | perl -lpe '$_=pack"H*",$_' > $EMU_PARAM_DIR/temp
-	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_csd bs=1 skip=0 count=16
+	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_csd bs=1 skip=0 count=16 2>/dev/null
 
 	# Ext CSD binary data
 	EXTCSD=`cat '/sys/kernel/debug/mmc0/mmc0:0001/ext_csd' | sed 's/.\{2\}/& /g'`
@@ -1042,7 +1040,7 @@ if [ "$t" = "$fru_timer" ]; then
 		EXTCSD=`printf 'ff %.0s' $(seq 1 16)`
 	fi
 	echo $EXTCSD |tr -d ' ' | tr -d '\n' | perl -lpe '$_=pack"H*",$_' > $EMU_PARAM_DIR/temp
-	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_extcsd bs=1 skip=0 count=512
+	dd if=$EMU_PARAM_DIR/temp of=$EMU_PARAM_DIR/emmc_extcsd bs=1 skip=0 count=512 2>/dev/null
 
 	rm $EMU_PARAM_DIR/temp
 

--- a/mlx-OpenIPMI.spec
+++ b/mlx-OpenIPMI.spec
@@ -102,10 +102,6 @@ rm -f %{buildroot}/usr/lib64/OpenIPMI/*.la %{buildroot}/usr/lib64/OpenIPMI/*.a
 /var/ipmi_sim/mellanox/sdr.30.main
 /lib/systemd/system/set_emu_param.service
 /lib/systemd/system/mlx_ipmid.service
-/etc/logrotate.d/mlx_ipmid
-/etc/logrotate.d/set_emu_param
-/etc/rsyslog.d/mlx_ipmid.conf
-/etc/rsyslog.d/set_emu_param.conf
 /usr/lib64/OpenIPMI/*.so*
 
 %changelog


### PR DESCRIPTION
In RHCOS deployments, DPU provisioning can fail because mlx-openipmi services still depend on /run/log-based logging. This path is not compatible with the affected deployment flow.

Switch both mlx_ipmid and set_emu_param services to journald and remove the related rsyslog/logrotate packaging artifacts so no service depends on /run/log paths.

After redirecting service output to journald, three logging behavior changes are relevant:

1) Service logging backend changes from file/rsyslog output in /run/log to
   systemd-journald stream capture.

2) Repeated sensor polling messages like:
   "Error getting sensor value (30,0,x): No such file or directory,
    Unable to open sensor file"
   become visible. These are expected when set_emu_param intentionally removes
   sensor files for unavailable data paths (for example disconnected QSFP or
   unavailable DIMM temperature sources). This behavior is not a new functional
   regression; it is surfaced more clearly once logs are in journald.
   To keep logs focused on actionable issues, add "-n" to ipmi_sim to disable
   stdio console I/O and reduce non-operational runtime output in journald.

3) set_emu_param helper command output that is expected but not actionable,
   including:
   - "256+0 records in"
   - "256+0 records out"
   - "256 bytes copied, ..."
   - repeated "inet <ip> netmask ... broadcast ..." probe lines Silence these by redirecting dd/probe command output so journal logs keep operational errors while dropping routine noise.

These updates restore RHCOS provisioning compatibility and make service logs readable for debugging actual failures.